### PR TITLE
v0.6: tags, show, equals, parse, and fast-check integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ npm install tagged-ts
 - **Type guards** — per-member guards that narrow the union, plus a `memberOfUnion` guard
 - **Pattern matching** — exhaustive `match`, widened `matchW`, partial `matchOr`, and curried `matcher`/`matcherW` variants
 - **Union return types** — constructors return the full union type (e.g. `Maybe<A>`), forcing pattern matching for safe access
+- **Batteries included** — generated `tags` list, `show` pretty-printer, structural `equals`, and shallow `parse`
+- **Property-based testing** — optional `tagged-ts/fast-check` entry point generates `fc.Arbitrary<Union>` from a field-arbitrary spec
 
 ## Modules
 
@@ -26,6 +28,7 @@ tagged-ts provides two constructor styles as separate submodules. Pick the one t
 |---|---|---|
 | `tagged-ts/named` | Object with named fields | `Maybe.Just({ value: 42 })` |
 | `tagged-ts/positional` | Positional arguments | `Maybe.Just(42)` |
+| `tagged-ts/fast-check` | fast-check `Arbitrary` builder (optional peer dep) | `mkArbitrary<Maybe<number>>({ ... })` |
 
 The root `tagged-ts` module exports only shared types (type lambdas, `MkData`, etc.). To create tagged unions, import from one of the submodules.
 
@@ -240,6 +243,116 @@ const describe = Maybe.matcherW<number, number | string>({
 
 describe(Maybe.Just({ value: 42 })) // number | string
 ```
+
+## Utilities
+
+Every tagged union comes with four generated utilities, available on both the `tagged-ts/named` and `tagged-ts/positional` modules.
+
+### `tags` — Readonly list of member tags
+
+A frozen array of all member tag strings, in the order they were declared. Useful for runtime enumeration, validation, dropdown options, etc.
+
+```ts
+Maybe.tags // readonly ['Just', 'Nothing']
+
+for (const tag of Maybe.tags) {
+  console.log(tag)
+}
+```
+
+### `show(value)` — Pretty-printer
+
+Formats a union value as a string. The format depends on the constructor style:
+
+```ts
+// Named:    Tag({ field: value })
+import { mkTaggedUnion } from 'tagged-ts/named'
+const Maybe = mkTaggedUnion<MaybeLambda>({ Just: true, Nothing: false })
+
+Maybe.show(Maybe.Just({ value: 42 }))  // 'Just({ value: 42 })'
+Maybe.show(Maybe.Nothing)              // 'Nothing'
+
+// Positional: Tag(v1, v2)
+import { mkTaggedUnion } from 'tagged-ts/positional'
+const Stream = mkTaggedUnion<StreamLambda>()({
+  Emit: ['state', 'value'],
+  End: [],
+})
+
+Stream.show(Stream.Emit('s', 42))  // 'Emit("s", 42)'
+Stream.show(Stream.End)            // 'End'
+```
+
+Field values are formatted with `JSON.stringify`.
+
+### `equals(a, b)` — Structural deep equality
+
+Compares two union values structurally. Returns `true` when both have the same discriminant and all fields are deeply equal (recursive over plain objects and arrays; primitives compared with `Object.is`, so `NaN === NaN`).
+
+```ts
+Maybe.equals(Maybe.Just({ value: 42 }), Maybe.Just({ value: 42 }))  // true
+Maybe.equals(Maybe.Just({ value: 42 }), Maybe.Nothing)              // false
+Maybe.equals(
+  Maybe.Just({ value: { a: 1, b: [1, 2] } }),
+  Maybe.Just({ value: { a: 1, b: [1, 2] } }),
+)                                                                   // true (deep)
+```
+
+Non-plain objects (Map, Set, Date, class instances) fall back to reference equality.
+
+### `parse(x)` — Shallow tag-based narrowing
+
+Parses an `unknown` value to the union if it has the discriminant key set to one of the known member tags. Returns the value typed as the union, or `undefined` on mismatch.
+
+```ts
+const raw: unknown = JSON.parse(input)
+const m = Maybe.parse(raw)
+if (m) {
+  Maybe.match(m, {
+    Just: x => x.value,
+    Nothing: () => 0,
+  })
+}
+```
+
+This is a **shallow** check: only the discriminant is validated — field shapes are not checked. Compose with a schema library (zod, valibot, etc.) if you need deeper validation.
+
+## Property-Based Testing
+
+The `tagged-ts/fast-check` entry point generates [fast-check](https://github.com/dubzzz/fast-check) `Arbitrary` instances for your unions. `fast-check` is an optional peer dependency — you only need it installed if you import from this entry point.
+
+```ts
+import fc from 'fast-check'
+import { mkArbitrary } from 'tagged-ts/fast-check'
+
+type Nothing = { readonly tag: 'Nothing' }
+type Just<A> = { readonly tag: 'Just'; readonly value: A }
+type Maybe<A> = Just<A> | Nothing
+
+// Specify an arbitrary per field, keyed by member tag.
+// Nullary members take `{}`.
+const arbMaybe = mkArbitrary<Maybe<number>>({
+  Just: { value: fc.integer() },
+  Nothing: {},
+})
+
+fc.assert(
+  fc.property(arbMaybe, m => m.tag === 'Just' || m.tag === 'Nothing'),
+)
+```
+
+For custom discriminant keys, use `mkArbitraryCustom`:
+
+```ts
+import { mkArbitraryCustom } from 'tagged-ts/fast-check'
+
+const arbCounter = mkArbitraryCustom<CounterAction, 'type'>('type', {
+  Increment: { amount: fc.integer() },
+  Reset: {},
+})
+```
+
+The spec uses named fields for both styles — it operates on the union's underlying shape, not the constructor API. The result works equally well for unions created with either `tagged-ts/named` or `tagged-ts/positional`.
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,16 @@
         "types": "./dist/positional/index.d.cts",
         "default": "./dist/positional/index.cjs"
       }
+    },
+    "./fast-check": {
+      "import": {
+        "types": "./dist/fast-check/index.d.ts",
+        "default": "./dist/fast-check/index.js"
+      },
+      "require": {
+        "types": "./dist/fast-check/index.d.cts",
+        "default": "./dist/fast-check/index.cjs"
+      }
     }
   },
   "files": [
@@ -44,7 +54,7 @@
   "sideEffects": false,
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "rm -rf dist && rollup -c rollup.config.mjs && tsc -p tsconfig.build.json && cp dist/index.d.ts dist/index.d.cts && cp dist/named/index.d.ts dist/named/index.d.cts && cp dist/positional/index.d.ts dist/positional/index.d.cts",
+    "build": "rm -rf dist && rollup -c rollup.config.mjs && tsc -p tsconfig.build.json && cp dist/index.d.ts dist/index.d.cts && cp dist/named/index.d.ts dist/named/index.d.cts && cp dist/positional/index.d.ts dist/positional/index.d.cts && cp dist/fast-check/index.d.ts dist/fast-check/index.d.cts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -74,6 +84,14 @@
     "rollup-plugin-swc3": "^0.12.1",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
+  },
+  "peerDependencies": {
+    "fast-check": "^3.0.0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "fast-check": {
+      "optional": true
+    }
   },
   "keywords": [
     "union",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -46,8 +46,14 @@ const entry = (input, outDir) => ({
   },
 })
 
+const fastCheckEntry = {
+  ...entry('src/fast-check/index.ts', 'dist/fast-check'),
+  external: ['fast-check'],
+}
+
 export default [
   entry('src/index.ts', 'dist'),
   entry('src/named/index.ts', 'dist/named'),
   entry('src/positional/index.ts', 'dist/positional'),
+  fastCheckEntry,
 ]

--- a/src/fast-check/index.ts
+++ b/src/fast-check/index.ts
@@ -1,0 +1,148 @@
+/**
+ * fast-check arbitrary generators for tagged unions.
+ *
+ * Produces `Arbitrary<Union>` instances from a spec of field arbitraries
+ * keyed by member tag. Works with both the named and positional
+ * constructor styles — the generated shape is identical, only the
+ * constructor API differs.
+ *
+ * Requires `fast-check` as a peer dependency.
+ *
+ * @example
+ * ```ts
+ * import fc from 'fast-check'
+ * import { mkArbitrary } from 'tagged-ts/fast-check'
+ *
+ * type Nothing = { readonly tag: 'Nothing' }
+ * type Just<A> = { readonly tag: 'Just'; readonly value: A }
+ * type Maybe<A> = Just<A> | Nothing
+ *
+ * const arbMaybe = mkArbitrary<Maybe<number>>({
+ *   Just: { value: fc.integer() },
+ *   Nothing: {},
+ * })
+ *
+ * fc.assert(
+ *   fc.property(arbMaybe, m => typeof m.tag === 'string'),
+ * )
+ * ```
+ *
+ * @since 0.6.0
+ */
+
+import fc, { type Arbitrary } from 'fast-check'
+
+// ---------------------------------------------------------------------------
+// Spec types
+// ---------------------------------------------------------------------------
+
+/**
+ * Record of field arbitraries matching the field types of a single
+ * non-nullary union member.
+ *
+ * @since 0.6.0
+ */
+export type FieldArbs<Fields> = {
+  [K in keyof Fields]: Arbitrary<Fields[K]>
+}
+
+/**
+ * Spec for building an `Arbitrary<U>` for a discriminated union `U`.
+ *
+ * For each member (keyed by its discriminant value):
+ * - Nullary members (no fields beyond the discriminant) take `{}`.
+ * - Non-nullary members take a record of field arbitraries keyed by
+ *   field name.
+ *
+ * `DK` defaults to `'tag'`. Override when your union uses a different
+ * discriminant key.
+ *
+ * @since 0.6.0
+ */
+export type ArbitrarySpec<U extends object, DK extends string = 'tag'> = {
+  [K in U[DK & keyof U] & string]: {} extends Omit<
+    Extract<U, { [P in DK]: K }>,
+    DK
+  >
+    ? Record<string, never>
+    : FieldArbs<Omit<Extract<U, { [P in DK]: K }>, DK>>
+}
+
+// ---------------------------------------------------------------------------
+// Runtime implementation
+// ---------------------------------------------------------------------------
+
+const mkArbitraryImpl = <U extends object>(
+  dk: string,
+  spec: Record<string, Record<string, Arbitrary<unknown>>>,
+): Arbitrary<U> => {
+  const arbs: Arbitrary<unknown>[] = []
+  for (const [memberTag, fieldSpec] of Object.entries(spec)) {
+    const fieldEntries = Object.entries(fieldSpec)
+    if (fieldEntries.length === 0) {
+      arbs.push(fc.constant({ [dk]: memberTag }))
+    } else {
+      const recordSpec: Record<string, Arbitrary<unknown>> = {}
+      for (const [k, v] of fieldEntries) recordSpec[k] = v
+      arbs.push(
+        fc.record(recordSpec).map(fields => ({ [dk]: memberTag, ...fields })),
+      )
+    }
+  }
+  if (arbs.length === 0) {
+    throw new Error('mkArbitrary: spec must contain at least one member')
+  }
+  return fc.oneof(
+    ...(arbs as [Arbitrary<unknown>, ...Arbitrary<unknown>[]]),
+  ) as Arbitrary<U>
+}
+
+// ---------------------------------------------------------------------------
+// Main API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fast-check `Arbitrary<U>` for a discriminated union using the
+ * default discriminant key `'tag'`. For custom discriminants, use
+ * `mkArbitraryCustom`.
+ *
+ * @example
+ * ```ts
+ * const arbMaybe = mkArbitrary<Maybe<number>>({
+ *   Just: { value: fc.integer() },
+ *   Nothing: {},
+ * })
+ * ```
+ *
+ * @since 0.6.0
+ */
+export const mkArbitrary = <U extends object>(
+  spec: ArbitrarySpec<U, 'tag'>,
+): Arbitrary<U> =>
+  mkArbitraryImpl<U>(
+    'tag',
+    spec as Record<string, Record<string, Arbitrary<unknown>>>,
+  )
+
+/**
+ * Build a fast-check `Arbitrary<U>` for a discriminated union with a
+ * custom discriminant key.
+ *
+ * @example
+ * ```ts
+ * const arbCounter = mkArbitraryCustom<CounterAction, 'type'>('type', {
+ *   Increment: { amount: fc.integer() },
+ *   Reset: {},
+ * })
+ * ```
+ *
+ * @since 0.6.0
+ */
+export const mkArbitraryCustom = <U extends object, DK extends string>(
+  dk: DK,
+  spec: ArbitrarySpec<U, DK>,
+): Arbitrary<U> =>
+  mkArbitraryImpl<U>(
+    dk,
+    spec as Record<string, Record<string, Arbitrary<unknown>>>,
+  )

--- a/src/internal/shared.ts
+++ b/src/internal/shared.ts
@@ -448,7 +448,250 @@ export type MatcherW<
           ) => (a: ApplyType0<F>) => ReturnType<Cases[DataKeys<F>]>
 
 // ---------------------------------------------------------------------------
+// Tags (readonly list of member tag strings)
+// ---------------------------------------------------------------------------
+
+/**
+ * A readonly list of all member tag strings for a tagged union, in the
+ * order they were declared in the member spec.
+ *
+ * Useful for runtime enumeration: iterating every case, building dropdown
+ * options, generating error messages, etc.
+ *
+ * @since 0.6.0
+ */
+export type Tags<F extends TaggedLambda0> = ReadonlyArray<DataKeys<F>>
+
+// ---------------------------------------------------------------------------
+// Equals (structural deep equality)
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural deep equality for two values of a tagged union.
+ *
+ * Returns `true` when both values have the same discriminant and all
+ * fields are structurally equal (recursive comparison over plain objects
+ * and arrays; primitives compared with `Object.is`).
+ *
+ * @since 0.6.0
+ */
+export type Equals<F extends TaggedLambda0> = F extends TaggedLambda4
+  ? <S, R, E, A>(
+      a: ApplyType4<F, S, R, E, A>,
+      b: ApplyType4<F, S, R, E, A>,
+    ) => boolean
+  : F extends TaggedLambda3
+    ? <R, E, A>(a: ApplyType3<F, R, E, A>, b: ApplyType3<F, R, E, A>) => boolean
+    : F extends TaggedLambda2
+      ? <E, A>(a: ApplyType2<F, E, A>, b: ApplyType2<F, E, A>) => boolean
+      : F extends TaggedLambda1
+        ? <A>(a: ApplyType1<F, A>, b: ApplyType1<F, A>) => boolean
+        : (a: ApplyType0<F>, b: ApplyType0<F>) => boolean
+
+// ---------------------------------------------------------------------------
+// Parse (shallow tag-based narrow from unknown)
+// ---------------------------------------------------------------------------
+
+/**
+ * Shallow parser that narrows an `unknown` value to the tagged union if it
+ * has the discriminant key set to one of the known member tags.
+ *
+ * This is a *shallow* check: only the discriminant is validated — field
+ * shapes are **not** checked. Compose with a schema library
+ * (zod, valibot, etc.) if you need deeper validation.
+ *
+ * @since 0.6.0
+ */
+export type Parse<F extends TaggedLambda0> = F extends TaggedLambda4
+  ? <S, R, E, A>(x: unknown) => ApplyType4<F, S, R, E, A> | undefined
+  : F extends TaggedLambda3
+    ? <R, E, A>(x: unknown) => ApplyType3<F, R, E, A> | undefined
+    : F extends TaggedLambda2
+      ? <E, A>(x: unknown) => ApplyType2<F, E, A> | undefined
+      : F extends TaggedLambda1
+        ? <A>(x: unknown) => ApplyType1<F, A> | undefined
+        : (x: unknown) => ApplyType0<F> | undefined
+
+// ---------------------------------------------------------------------------
 // Shared runtime
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural deep equality used by generated `equals`.
+ *
+ * - Primitives compared with `Object.is` (so `NaN === NaN`)
+ * - Arrays compared element-wise (same length)
+ * - Plain objects compared by own enumerable keys (same set)
+ * - All other object types (Map, Set, Date, class instances, etc.)
+ *   compared with `Object.is` (reference equality)
+ * - Cyclic structures handled coinductively: if we encounter a pair
+ *   (a, b) already on the comparison stack, we assume them equal. This
+ *   means two self-referential structures with the same shape return
+ *   `true` instead of stack-overflowing.
+ *
+ * @internal
+ */
+export const deepEquals = (a: unknown, b: unknown): boolean =>
+  deepEqualsInner(a, b, new WeakMap())
+
+const deepEqualsInner = (
+  a: unknown,
+  b: unknown,
+  seen: WeakMap<object, WeakSet<object>>,
+): boolean => {
+  if (Object.is(a, b)) return true
+  if (typeof a !== 'object' || typeof b !== 'object') return false
+  if (a === null || b === null) return false
+
+  // Cycle guard: if we're already comparing this (a, b) pair further up
+  // the stack, coinductively assume they're equal. Without this, cyclic
+  // structures would recurse forever.
+  const seenForA = seen.get(a as object)
+  if (seenForA?.has(b as object)) return true
+  if (seenForA) seenForA.add(b as object)
+  else seen.set(a as object, new WeakSet([b as object]))
+
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqualsInner(a[i], b[i], seen)) return false
+    }
+    return true
+  }
+  if (Array.isArray(b)) return false
+  // Only treat plain objects as structurally comparable. Non-plain objects
+  // (Map, Set, Date, class instances with custom prototypes) fall through to
+  // reference equality, which Object.is already handled above.
+  const protoA = Object.getPrototypeOf(a)
+  const protoB = Object.getPrototypeOf(b)
+  if (
+    (protoA !== Object.prototype && protoA !== null) ||
+    (protoB !== Object.prototype && protoB !== null)
+  ) {
+    return false
+  }
+  const ak = Object.keys(a as object)
+  const bk = Object.keys(b as object)
+  if (ak.length !== bk.length) return false
+  for (const k of ak) {
+    if (!Object.hasOwn(b as object, k)) return false
+    if (
+      !deepEqualsInner(
+        (a as Record<string, unknown>)[k],
+        (b as Record<string, unknown>)[k],
+        seen,
+      )
+    )
+      return false
+  }
+  return true
+}
+
+/**
+ * Format an arbitrary value for inclusion in a `show` output string.
+ *
+ * Produces readable output similar to `util.inspect`:
+ *
+ * - Primitives: `42`, `true`, `null`, `undefined`, `"hi"`, `42n`, `Symbol(x)`
+ * - Functions: `[Function: name]`
+ * - Arrays: `[1, 2, 3]`
+ * - Plain objects: `{ key: value }`
+ * - Class instances: `ClassName { field: value }`
+ * - Dates: `Date("2024-01-01T00:00:00.000Z")`
+ * - RegExps: `/pattern/flags`
+ * - Errors: `TypeError("message")`
+ * - Maps: `Map("k" => 1, "j" => 2)`
+ * - Sets: `Set(1, 2, 3)`
+ * - Cycles: `[Circular]` placeholder where a value refers to an ancestor
+ *
+ * @internal
+ */
+export const formatValue = (v: unknown): string => {
+  const seen = new WeakSet<object>()
+  const go = (x: unknown): string => {
+    if (x === null) return 'null'
+    if (x === undefined) return 'undefined'
+    const t = typeof x
+    if (t === 'string') return JSON.stringify(x)
+    if (t === 'number') {
+      // Preserve -0 which String() would render as "0"
+      return Object.is(x, -0) ? '-0' : String(x)
+    }
+    if (t === 'boolean') return String(x)
+    if (t === 'bigint') return `${String(x)}n`
+    if (t === 'symbol') return (x as symbol).toString()
+    if (t === 'function') {
+      const name = (x as { name?: string }).name
+      return name ? `[Function: ${name}]` : '[Function]'
+    }
+    // From here on, x is a non-null object.
+    const obj = x as object
+    if (seen.has(obj)) return '[Circular]'
+    seen.add(obj)
+    if (Array.isArray(obj)) return `[${obj.map(go).join(', ')}]`
+    if (obj instanceof Date) return `Date(${JSON.stringify(obj.toISOString())})`
+    if (obj instanceof RegExp) return obj.toString()
+    if (obj instanceof Error)
+      return `${obj.name}(${JSON.stringify(obj.message)})`
+    if (obj instanceof Map) {
+      const entries = Array.from(obj.entries())
+        .map(([k, v]) => `${go(k)} => ${go(v)}`)
+        .join(', ')
+      return `Map(${entries})`
+    }
+    if (obj instanceof Set) {
+      const values = Array.from(obj.values()).map(go).join(', ')
+      return `Set(${values})`
+    }
+    const keys = Object.keys(obj)
+    const inner = keys
+      .map(k => `${k}: ${go((obj as Record<string, unknown>)[k])}`)
+      .join(', ')
+    const proto = Object.getPrototypeOf(obj)
+    const isPlain = proto === null || proto === Object.prototype
+    if (isPlain) return keys.length === 0 ? '{}' : `{ ${inner} }`
+    const className =
+      (proto?.constructor as { name?: string } | undefined)?.name ?? 'Object'
+    return keys.length === 0 ? `${className} {}` : `${className} { ${inner} }`
+  }
+  return go(v)
+}
+
+/**
+ * Build the shared (style-agnostic) runtime features: tags, equals, parse.
+ * Used by both named and positional modules.
+ *
+ * @internal
+ */
+export const mkSharedFeatures = (
+  dk: string,
+  memberTags: string[],
+): {
+  tags: readonly string[]
+  equals: (a: unknown, b: unknown) => boolean
+  parse: (x: unknown) => unknown
+} => {
+  const tags = Object.freeze([...memberTags])
+  const tagSet = new Set(memberTags)
+
+  const equals = (a: unknown, b: unknown): boolean => deepEquals(a, b)
+
+  const parse = (x: unknown): unknown => {
+    if (typeof x !== 'object' || x === null) return undefined
+    if (Array.isArray(x)) return undefined
+    // Require an *own* discriminant key. Prevents Object.create-based
+    // prototype pollution from passing as a valid union member.
+    if (!Object.hasOwn(x, dk)) return undefined
+    const tag = (x as Record<string, unknown>)[dk]
+    if (typeof tag !== 'string' || !tagSet.has(tag)) return undefined
+    return x
+  }
+
+  return { tags, equals, parse }
+}
+
+// ---------------------------------------------------------------------------
+// Guards and matchers runtime
 // ---------------------------------------------------------------------------
 
 /**

--- a/src/named/index.ts
+++ b/src/named/index.ts
@@ -11,6 +11,7 @@
  */
 
 import type {
+  Equals,
   Guards,
   Match,
   Matcher,
@@ -19,8 +20,14 @@ import type {
   MatchW,
   MemberShape,
   NullaryConstructor,
+  Parse,
+  Tags,
 } from '../internal/shared.js'
-import { mkGuardsAndMatchers } from '../internal/shared.js'
+import {
+  formatValue,
+  mkGuardsAndMatchers,
+  mkSharedFeatures,
+} from '../internal/shared.js'
 import type {
   ApplyData0,
   ApplyData1,
@@ -41,12 +48,15 @@ import type {
 } from '../Lambda.js'
 
 export type {
+  Equals,
   Guards,
   Match,
   Matcher,
   MatcherW,
   MatchOr,
   MatchW,
+  Parse,
+  Tags,
 } from '../internal/shared.js'
 // Re-export shared types for single-import convenience
 export type {
@@ -172,11 +182,34 @@ export type Constructors<
 }
 
 // ---------------------------------------------------------------------------
+// Show (named/object-style formatter)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pretty-printer for a tagged union (named/object style).
+ *
+ * Produces `"Tag({ field1: value1, field2: value2 })"` for non-nullary
+ * members and just `"Tag"` for nullary members. Field values are formatted
+ * with `JSON.stringify`.
+ *
+ * @since 0.6.0
+ */
+export type Show<F extends TaggedLambda0> = F extends TaggedLambda4
+  ? <S, R, E, A>(a: ApplyType4<F, S, R, E, A>) => string
+  : F extends TaggedLambda3
+    ? <R, E, A>(a: ApplyType3<F, R, E, A>) => string
+    : F extends TaggedLambda2
+      ? <E, A>(a: ApplyType2<F, E, A>) => string
+      : F extends TaggedLambda1
+        ? <A>(a: ApplyType1<F, A>) => string
+        : (a: ApplyType0<F>) => string
+
+// ---------------------------------------------------------------------------
 // TaggedUnion result type
 // ---------------------------------------------------------------------------
 
 /**
- * The combined result: constructors + guards + match variants.
+ * The combined result: constructors + guards + match variants + utilities.
  *
  * @since 0.4.0
  */
@@ -190,6 +223,10 @@ export type TaggedUnion<
   readonly matchOr: MatchOr<F, DiscriminantKey>
   readonly matcher: Matcher<F, DiscriminantKey>
   readonly matcherW: MatcherW<F, DiscriminantKey>
+  readonly tags: Tags<F>
+  readonly show: Show<F>
+  readonly equals: Equals<F>
+  readonly parse: Parse<F>
 }
 
 // ---------------------------------------------------------------------------
@@ -201,6 +238,7 @@ const mkTaggedUnionImpl = <F extends TaggedLambda0, DK extends string>(
   members: Record<string, boolean>,
 ): TaggedUnion<F, DK> => {
   const constructors: Record<string, unknown> = {}
+  const memberTags = Object.keys(members)
 
   for (const [memberTag, hasFields] of Object.entries(members)) {
     const discriminantPair = { [dk]: memberTag }
@@ -214,9 +252,25 @@ const mkTaggedUnionImpl = <F extends TaggedLambda0, DK extends string>(
     }
   }
 
-  const shared = mkGuardsAndMatchers(dk, Object.keys(members))
+  const guardsAndMatchers = mkGuardsAndMatchers(dk, memberTags)
+  const features = mkSharedFeatures(dk, memberTags)
 
-  return { ...constructors, ...shared } as unknown as TaggedUnion<F, DK>
+  const show = (a: unknown): string => {
+    if (typeof a !== 'object' || a === null) return String(a)
+    const rec = a as Record<string, unknown>
+    const tag = rec[dk]
+    const fieldKeys = Object.keys(rec).filter(k => k !== dk)
+    if (fieldKeys.length === 0) return String(tag)
+    const inner = fieldKeys.map(k => `${k}: ${formatValue(rec[k])}`).join(', ')
+    return `${String(tag)}({ ${inner} })`
+  }
+
+  return {
+    ...constructors,
+    ...guardsAndMatchers,
+    ...features,
+    show,
+  } as unknown as TaggedUnion<F, DK>
 }
 
 // ---------------------------------------------------------------------------

--- a/src/positional/index.ts
+++ b/src/positional/index.ts
@@ -12,6 +12,7 @@
  */
 
 import type {
+  Equals,
   Guards,
   Match,
   Matcher,
@@ -20,8 +21,14 @@ import type {
   MatchW,
   MemberShape,
   NullaryConstructor,
+  Parse,
+  Tags,
 } from '../internal/shared.js'
-import { mkGuardsAndMatchers } from '../internal/shared.js'
+import {
+  formatValue,
+  mkGuardsAndMatchers,
+  mkSharedFeatures,
+} from '../internal/shared.js'
 import type { StringKeyOf } from '../internal/Utils.js'
 import type {
   ApplyData0,
@@ -43,12 +50,15 @@ import type {
 } from '../Lambda.js'
 
 export type {
+  Equals,
   Guards,
   Match,
   Matcher,
   MatcherW,
   MatchOr,
   MatchW,
+  Parse,
+  Tags,
 } from '../internal/shared.js'
 // Re-export shared types for single-import convenience
 export type {
@@ -215,11 +225,34 @@ export type Constructors<
 }
 
 // ---------------------------------------------------------------------------
+// Show (positional formatter)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pretty-printer for a tagged union (positional style).
+ *
+ * Produces `"Tag(value1, value2)"` for non-nullary members (values in the
+ * declared order from the member spec) and just `"Tag"` for nullary
+ * members. Field values are formatted with `JSON.stringify`.
+ *
+ * @since 0.6.0
+ */
+export type Show<F extends TaggedLambda0> = F extends TaggedLambda4
+  ? <S, R, E, A>(a: ApplyType4<F, S, R, E, A>) => string
+  : F extends TaggedLambda3
+    ? <R, E, A>(a: ApplyType3<F, R, E, A>) => string
+    : F extends TaggedLambda2
+      ? <E, A>(a: ApplyType2<F, E, A>) => string
+      : F extends TaggedLambda1
+        ? <A>(a: ApplyType1<F, A>) => string
+        : (a: ApplyType0<F>) => string
+
+// ---------------------------------------------------------------------------
 // TaggedUnion result type
 // ---------------------------------------------------------------------------
 
 /**
- * The combined result: constructors + guards + match variants.
+ * The combined result: constructors + guards + match variants + utilities.
  *
  * @since 0.5.0
  */
@@ -237,6 +270,10 @@ export type TaggedUnion<
   readonly matchOr: MatchOr<F, DiscriminantKey>
   readonly matcher: Matcher<F, DiscriminantKey>
   readonly matcherW: MatcherW<F, DiscriminantKey>
+  readonly tags: Tags<F>
+  readonly show: Show<F>
+  readonly equals: Equals<F>
+  readonly parse: Parse<F>
 }
 
 // ---------------------------------------------------------------------------
@@ -252,8 +289,11 @@ const mkTaggedUnionImpl = <
   members: Spec,
 ): TaggedUnion<F, DK, Spec> => {
   const constructors: Record<string, unknown> = {}
+  const memberTags = Object.keys(members)
+  const fieldOrder: Record<string, readonly string[]> = {}
 
   for (const [memberTag, fieldNames] of Object.entries(members)) {
+    fieldOrder[memberTag] = fieldNames
     const discriminantPair = { [dk]: memberTag }
     if (fieldNames.length === 0) {
       constructors[memberTag] = discriminantPair
@@ -268,9 +308,25 @@ const mkTaggedUnionImpl = <
     }
   }
 
-  const shared = mkGuardsAndMatchers(dk, Object.keys(members))
+  const guardsAndMatchers = mkGuardsAndMatchers(dk, memberTags)
+  const features = mkSharedFeatures(dk, memberTags)
 
-  return { ...constructors, ...shared } as unknown as TaggedUnion<F, DK, Spec>
+  const show = (a: unknown): string => {
+    if (typeof a !== 'object' || a === null) return String(a)
+    const rec = a as Record<string, unknown>
+    const tag = rec[dk]
+    const orderedFields = fieldOrder[tag as string] ?? []
+    if (orderedFields.length === 0) return String(tag)
+    const inner = orderedFields.map(k => formatValue(rec[k])).join(', ')
+    return `${String(tag)}(${inner})`
+  }
+
+  return {
+    ...constructors,
+    ...guardsAndMatchers,
+    ...features,
+    show,
+  } as unknown as TaggedUnion<F, DK, Spec>
 }
 
 // ---------------------------------------------------------------------------

--- a/test/fast-check/mkArbitrary.test.ts
+++ b/test/fast-check/mkArbitrary.test.ts
@@ -1,0 +1,226 @@
+import fc from 'fast-check'
+import { describe, expect, it } from 'vitest'
+import { mkArbitrary, mkArbitraryCustom } from '../../src/fast-check'
+
+// ===========================================================================
+// Setup
+// ===========================================================================
+
+type Nothing = { readonly tag: 'Nothing' }
+type Just<A> = { readonly tag: 'Just'; readonly value: A }
+type Maybe<A> = Just<A> | Nothing
+
+type Failure<E> = { readonly tag: 'Failure'; readonly error: E }
+type Success<A> = { readonly tag: 'Success'; readonly value: A }
+type Result<E, A> = Success<A> | Failure<E>
+
+type Emit<S, A> = {
+  readonly tag: 'Emit'
+  readonly state: S
+  readonly value: A
+}
+type End = { readonly tag: 'End' }
+type Stream<S, A> = Emit<S, A> | End
+
+type Increment = { readonly type: 'Increment'; readonly amount: number }
+type Reset = { readonly type: 'Reset' }
+type CounterAction = Increment | Reset
+
+// ===========================================================================
+// mkArbitrary
+// ===========================================================================
+
+describe('mkArbitrary', () => {
+  it('produces union members with the correct discriminant', () => {
+    const arbMaybe = mkArbitrary<Maybe<number>>({
+      Just: { value: fc.integer() },
+      Nothing: {},
+    })
+
+    fc.assert(
+      fc.property(arbMaybe, m => m.tag === 'Just' || m.tag === 'Nothing'),
+    )
+  })
+
+  it('produces nullary members as constants', () => {
+    const arbMaybe = mkArbitrary<Maybe<number>>({
+      Just: { value: fc.integer() },
+      Nothing: {},
+    })
+
+    fc.assert(
+      fc.property(arbMaybe, m => {
+        if (m.tag === 'Nothing') {
+          return Object.keys(m).length === 1
+        }
+        return typeof m.value === 'number'
+      }),
+    )
+  })
+
+  it('handles multi-field members', () => {
+    const arbStream = mkArbitrary<Stream<string, number>>({
+      Emit: { state: fc.string(), value: fc.integer() },
+      End: {},
+    })
+
+    fc.assert(
+      fc.property(arbStream, s => {
+        if (s.tag === 'End') return true
+        return typeof s.state === 'string' && typeof s.value === 'number'
+      }),
+    )
+  })
+
+  it('handles binary unions like Result', () => {
+    const arbResult = mkArbitrary<Result<string, number>>({
+      Success: { value: fc.integer() },
+      Failure: { error: fc.string() },
+    })
+
+    fc.assert(
+      fc.property(arbResult, r => {
+        if (r.tag === 'Success') return typeof r.value === 'number'
+        return typeof r.error === 'string'
+      }),
+    )
+  })
+
+  it('exercises all members over many runs', () => {
+    const arbMaybe = mkArbitrary<Maybe<number>>({
+      Just: { value: fc.integer() },
+      Nothing: {},
+    })
+
+    const seen = new Set<string>()
+    for (let i = 0; i < 200; i++) {
+      const sample = fc.sample(arbMaybe, 1)[0]
+      if (sample) seen.add(sample.tag)
+      if (seen.size === 2) break
+    }
+    expect(seen).toEqual(new Set(['Just', 'Nothing']))
+  })
+})
+
+// ===========================================================================
+// mkArbitraryCustom
+// ===========================================================================
+
+describe('mkArbitraryCustom', () => {
+  it('uses a custom discriminant key', () => {
+    const arbCounter = mkArbitraryCustom<CounterAction, 'type'>('type', {
+      Increment: { amount: fc.integer() },
+      Reset: {},
+    })
+
+    fc.assert(
+      fc.property(arbCounter, c => {
+        if (c.type === 'Reset') return true
+        return typeof c.amount === 'number'
+      }),
+    )
+  })
+
+  it('produces values without a `tag` key', () => {
+    const arbCounter = mkArbitraryCustom<CounterAction, 'type'>('type', {
+      Increment: { amount: fc.integer() },
+      Reset: {},
+    })
+
+    fc.assert(fc.property(arbCounter, c => !('tag' in c) && 'type' in c))
+  })
+})
+
+// ===========================================================================
+// Error cases
+// ===========================================================================
+
+describe('mkArbitrary error handling', () => {
+  it('throws on empty spec', () => {
+    expect(() =>
+      // biome-ignore lint/suspicious/noExplicitAny: exercising runtime error
+      mkArbitrary<Maybe<number>>({} as any),
+    ).toThrow(/at least one member/)
+  })
+
+  it('accepts partial spec at runtime — completeness is a TypeScript guarantee', () => {
+    // Documented behavior: mkArbitrary has no runtime type info, so it cannot
+    // detect a missing member. A spec with only some members produces an
+    // arbitrary that generates only those members. Completeness is enforced
+    // by `ArbitrarySpec`'s mapped type at compile time; bypassing it with
+    // `as any` is accepted at runtime and silently produces a partial
+    // generator. Callers wanting runtime validation should assert on the
+    // union tag list themselves.
+    const arbPartial = mkArbitrary<Maybe<number>>(
+      // biome-ignore lint/suspicious/noExplicitAny: exercising partial spec
+      { Just: { value: fc.integer() } } as any,
+    )
+    fc.assert(fc.property(arbPartial, m => m.tag === 'Just'))
+  })
+})
+
+// ===========================================================================
+// Integration: round-trip generated values through parse/equals/show
+// ===========================================================================
+
+import type { MkData, TaggedLambda1, TaggedLambda2 } from '../../src/named'
+import { mkTaggedUnion } from '../../src/named'
+
+interface MaybeLambda extends TaggedLambda1 {
+  readonly type: Maybe<this['A']>
+  readonly data: MkData<this['type']>
+}
+interface StreamLambda extends TaggedLambda2 {
+  readonly type: Stream<this['E'], this['A']>
+  readonly data: MkData<this['type']>
+}
+
+const MaybeU = mkTaggedUnion<MaybeLambda>({ Just: true, Nothing: false })
+const StreamU = mkTaggedUnion<StreamLambda>({ Emit: true, End: false })
+
+describe('mkArbitrary round-trips', () => {
+  const arbMaybe = mkArbitrary<Maybe<number>>({
+    Just: { value: fc.integer() },
+    Nothing: {},
+  })
+
+  it('generated values are parseable by the matching union', () => {
+    fc.assert(fc.property(arbMaybe, m => MaybeU.parse(m) !== undefined))
+  })
+
+  it('generated values survive JSON round-trip under equals', () => {
+    fc.assert(
+      fc.property(arbMaybe, m => {
+        const clone = JSON.parse(JSON.stringify(m)) as typeof m
+        return MaybeU.equals(m, clone)
+      }),
+    )
+  })
+
+  it('each generated value matches exactly one guard', () => {
+    fc.assert(
+      fc.property(arbMaybe, m => {
+        const hits = MaybeU.tags.filter(tag => {
+          const guard = MaybeU.is[tag as keyof typeof MaybeU.is] as (
+            x: unknown,
+          ) => boolean
+          return guard(m)
+        })
+        return hits.length === 1
+      }),
+    )
+  })
+
+  it('multi-field positional-style unions round-trip too', () => {
+    const arbStream = mkArbitrary<Stream<string, number>>({
+      Emit: { state: fc.string(), value: fc.integer() },
+      End: {},
+    })
+    fc.assert(
+      fc.property(arbStream, s => {
+        const clone = JSON.parse(JSON.stringify(s)) as typeof s
+        return StreamU.equals(s, clone) && StreamU.parse(s) !== undefined
+      }),
+    )
+  })
+})

--- a/test/named/features.test.ts
+++ b/test/named/features.test.ts
@@ -1,0 +1,606 @@
+import fc from 'fast-check'
+import { describe, expect, it } from 'vitest'
+import { mkArbitrary } from '../../src/fast-check'
+import type {
+  MkData,
+  TaggedLambda0,
+  TaggedLambda1,
+  TaggedLambda2,
+} from '../../src/named'
+import { mkTaggedUnion, mkTaggedUnionCustom } from '../../src/named'
+
+// ===========================================================================
+// Setup
+// ===========================================================================
+
+type Nothing = { readonly tag: 'Nothing' }
+type Just<A> = { readonly tag: 'Just'; readonly value: A }
+type Maybe<A> = Just<A> | Nothing
+
+interface MaybeLambda extends TaggedLambda1 {
+  readonly type: Maybe<this['A']>
+  readonly data: MkData<this['type']>
+}
+
+const Maybe = mkTaggedUnion<MaybeLambda>({ Just: true, Nothing: false })
+
+type Failure<E> = { readonly tag: 'Failure'; readonly error: E }
+type Success<A> = { readonly tag: 'Success'; readonly value: A }
+type Result<E, A> = Success<A> | Failure<E>
+
+interface ResultLambda extends TaggedLambda2 {
+  readonly type: Result<this['E'], this['A']>
+  readonly data: MkData<this['type']>
+}
+
+const Result = mkTaggedUnion<ResultLambda>({ Success: true, Failure: true })
+
+type Increment = { readonly type: 'Increment'; readonly amount: number }
+type Reset = { readonly type: 'Reset' }
+type CounterAction = Increment | Reset
+
+interface CounterActionLambda extends TaggedLambda0 {
+  readonly type: CounterAction
+  readonly data: MkData<this['type'], 'type'>
+}
+
+const CounterAction = mkTaggedUnionCustom<CounterActionLambda>()('type', {
+  Increment: true,
+  Reset: false,
+})
+
+// ===========================================================================
+// tags
+// ===========================================================================
+
+describe('tags', () => {
+  it('returns all member tag strings', () => {
+    expect(Maybe.tags).toEqual(['Just', 'Nothing'])
+    expect(Result.tags).toEqual(['Success', 'Failure'])
+    expect(CounterAction.tags).toEqual(['Increment', 'Reset'])
+  })
+
+  it('is frozen (readonly)', () => {
+    expect(Object.isFrozen(Maybe.tags)).toBe(true)
+  })
+
+  it('preserves spec order', () => {
+    const Ordered = mkTaggedUnion<MaybeLambda>({ Nothing: false, Just: true })
+    expect(Ordered.tags).toEqual(['Nothing', 'Just'])
+  })
+
+  it('actually refuses mutation (not just Object.isFrozen)', () => {
+    expect(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: exercising runtime freeze
+      ;(Maybe.tags as any).push('Bogus')
+    }).toThrow(TypeError)
+  })
+
+  it('returns the same reference each access (stable identity)', () => {
+    expect(Maybe.tags).toBe(Maybe.tags)
+  })
+})
+
+// ===========================================================================
+// show
+// ===========================================================================
+
+describe('show (named)', () => {
+  it('formats nullary members as just the tag', () => {
+    expect(Maybe.show(Maybe.Nothing)).toBe('Nothing')
+    expect(CounterAction.show(CounterAction.Reset)).toBe('Reset')
+  })
+
+  it('formats non-nullary members with named fields', () => {
+    expect(Maybe.show(Maybe.Just({ value: 42 }))).toBe('Just({ value: 42 })')
+    expect(Maybe.show(Maybe.Just({ value: 'hi' }))).toBe(
+      'Just({ value: "hi" })',
+    )
+  })
+
+  it('formats multiple fields', () => {
+    expect(Result.show(Result.Failure({ error: 'boom' }))).toBe(
+      'Failure({ error: "boom" })',
+    )
+  })
+
+  it('formats nested plain objects recursively', () => {
+    expect(Maybe.show(Maybe.Just({ value: { a: 1, b: [2, 3] } }))).toBe(
+      'Just({ value: { a: 1, b: [2, 3] } })',
+    )
+  })
+
+  it('handles custom discriminant key', () => {
+    expect(CounterAction.show(CounterAction.Increment({ amount: 3 }))).toBe(
+      'Increment({ amount: 3 })',
+    )
+  })
+
+  it('renders undefined field values', () => {
+    // Runtime edge: user passes explicit undefined
+    expect(
+      Maybe.show(Maybe.Just({ value: undefined as unknown as number })),
+    ).toBe('Just({ value: undefined })')
+  })
+
+  it('renders booleans and null', () => {
+    expect(Maybe.show(Maybe.Just({ value: true as unknown as number }))).toBe(
+      'Just({ value: true })',
+    )
+    expect(Maybe.show(Maybe.Just({ value: null as unknown as number }))).toBe(
+      'Just({ value: null })',
+    )
+  })
+
+  it('renders arrays with spaces', () => {
+    expect(
+      Maybe.show(Maybe.Just({ value: [1, 2, 3] as unknown as number })),
+    ).toBe('Just({ value: [1, 2, 3] })')
+  })
+
+  it('JSON-escapes strings with quotes and backslashes', () => {
+    expect(
+      Maybe.show(Maybe.Just({ value: 'say "hi"' as unknown as number })),
+    ).toBe('Just({ value: "say \\"hi\\"" })')
+  })
+
+  it('renders a tagged union nested inside another as a plain object', () => {
+    // Nested member is a plain object from formatValue's perspective.
+    expect(
+      Maybe.show(
+        Maybe.Just({
+          value: Maybe.Just({ value: 1 }) as unknown as number,
+        }),
+      ),
+    ).toBe('Just({ value: { tag: "Just", value: 1 } })')
+  })
+
+  it('renders bigint, symbol, function, -0', () => {
+    expect(Maybe.show(Maybe.Just({ value: 42n as unknown as number }))).toBe(
+      'Just({ value: 42n })',
+    )
+    expect(
+      Maybe.show(Maybe.Just({ value: Symbol('x') as unknown as number })),
+    ).toBe('Just({ value: Symbol(x) })')
+    expect(
+      Maybe.show(
+        Maybe.Just({
+          value: function foo() {} as unknown as number,
+        }),
+      ),
+    ).toBe('Just({ value: [Function: foo] })')
+    expect(Maybe.show(Maybe.Just({ value: -0 as unknown as number }))).toBe(
+      'Just({ value: -0 })',
+    )
+  })
+
+  it('renders Date, RegExp, Error', () => {
+    expect(
+      Maybe.show(
+        Maybe.Just({
+          value: new Date('2024-01-01T00:00:00.000Z') as unknown as number,
+        }),
+      ),
+    ).toBe('Just({ value: Date("2024-01-01T00:00:00.000Z") })')
+
+    expect(
+      Maybe.show(Maybe.Just({ value: /foo/gi as unknown as number })),
+    ).toBe('Just({ value: /foo/gi })')
+
+    expect(
+      Maybe.show(
+        Maybe.Just({ value: new TypeError('boom') as unknown as number }),
+      ),
+    ).toBe('Just({ value: TypeError("boom") })')
+  })
+
+  it('renders Map and Set', () => {
+    expect(
+      Maybe.show(
+        Maybe.Just({
+          value: new Map([
+            ['k', 1],
+            ['j', 2],
+          ]) as unknown as number,
+        }),
+      ),
+    ).toBe('Just({ value: Map("k" => 1, "j" => 2) })')
+    expect(
+      Maybe.show(
+        Maybe.Just({ value: new Set([1, 2, 3]) as unknown as number }),
+      ),
+    ).toBe('Just({ value: Set(1, 2, 3) })')
+  })
+
+  it('renders class instances with constructor name', () => {
+    class Point {
+      x: number
+      y: number
+      constructor(x: number, y: number) {
+        this.x = x
+        this.y = y
+      }
+    }
+    expect(
+      Maybe.show(Maybe.Just({ value: new Point(1, 2) as unknown as number })),
+    ).toBe('Just({ value: Point { x: 1, y: 2 } })')
+  })
+
+  it('marks cyclic references with [Circular]', () => {
+    const cyclic: { self?: unknown } = {}
+    cyclic.self = cyclic
+    expect(Maybe.show(Maybe.Just({ value: cyclic as unknown as number }))).toBe(
+      'Just({ value: { self: [Circular] } })',
+    )
+  })
+
+  it('renders empty plain object and empty array', () => {
+    expect(Maybe.show(Maybe.Just({ value: {} as unknown as number }))).toBe(
+      'Just({ value: {} })',
+    )
+    expect(Maybe.show(Maybe.Just({ value: [] as unknown as number }))).toBe(
+      'Just({ value: [] })',
+    )
+  })
+})
+
+// ===========================================================================
+// equals
+// ===========================================================================
+
+describe('equals', () => {
+  it('returns true for structurally identical members', () => {
+    expect(
+      Maybe.equals(Maybe.Just({ value: 42 }), Maybe.Just({ value: 42 })),
+    ).toBe(true)
+    expect(Maybe.equals(Maybe.Nothing, Maybe.Nothing)).toBe(true)
+  })
+
+  it('returns false for different discriminants', () => {
+    expect(Maybe.equals(Maybe.Just({ value: 42 }), Maybe.Nothing)).toBe(false)
+  })
+
+  it('returns false for different field values', () => {
+    expect(
+      Maybe.equals(Maybe.Just({ value: 42 }), Maybe.Just({ value: 43 })),
+    ).toBe(false)
+  })
+
+  it('compares nested objects structurally', () => {
+    const a = Maybe.Just({ value: { a: 1, b: [1, 2, 3] } })
+    const b = Maybe.Just({ value: { a: 1, b: [1, 2, 3] } })
+    expect(Maybe.equals(a, b)).toBe(true)
+  })
+
+  it('detects nested array differences', () => {
+    const a = Maybe.Just({ value: [1, 2, 3] as unknown as number })
+    const b = Maybe.Just({ value: [1, 2, 4] as unknown as number })
+    expect(Maybe.equals(a, b)).toBe(false)
+  })
+
+  it('handles NaN via Object.is', () => {
+    expect(
+      Maybe.equals(Maybe.Just({ value: NaN }), Maybe.Just({ value: NaN })),
+    ).toBe(true)
+  })
+
+  it('handles mixed nullary and non-nullary', () => {
+    expect(
+      CounterAction.equals(
+        CounterAction.Increment({ amount: 3 }),
+        CounterAction.Increment({ amount: 3 }),
+      ),
+    ).toBe(true)
+    expect(
+      CounterAction.equals(
+        CounterAction.Increment({ amount: 3 }),
+        CounterAction.Reset,
+      ),
+    ).toBe(false)
+  })
+
+  it('distinguishes cross-type primitives (1 vs "1")', () => {
+    expect(
+      Maybe.equals(
+        Maybe.Just({ value: 1 }),
+        Maybe.Just({ value: '1' as unknown as number }),
+      ),
+    ).toBe(false)
+  })
+
+  it('distinguishes null from undefined', () => {
+    expect(
+      Maybe.equals(
+        Maybe.Just({ value: null as unknown as number }),
+        Maybe.Just({ value: undefined as unknown as number }),
+      ),
+    ).toBe(false)
+  })
+
+  it('distinguishes arrays of different lengths with matching prefix', () => {
+    const a = Maybe.Just({ value: [1, 2] as unknown as number })
+    const b = Maybe.Just({ value: [1, 2, 3] as unknown as number })
+    expect(Maybe.equals(a, b)).toBe(false)
+  })
+
+  it('distinguishes same-size objects with different keys', () => {
+    const a = Maybe.Just({ value: { a: 1 } as unknown as number })
+    const b = Maybe.Just({ value: { b: 1 } as unknown as number })
+    expect(Maybe.equals(a, b)).toBe(false)
+  })
+
+  it('treats arrays and plain objects with array-like keys as unequal', () => {
+    const a = Maybe.Just({ value: [1, 2] as unknown as number })
+    const b = Maybe.Just({
+      value: { 0: 1, 1: 2, length: 2 } as unknown as number,
+    })
+    expect(Maybe.equals(a, b)).toBe(false)
+  })
+
+  it('falls back to reference equality for Date/Map/Set', () => {
+    const d = new Date(0)
+    expect(
+      Maybe.equals(
+        Maybe.Just({ value: d as unknown as number }),
+        Maybe.Just({ value: d as unknown as number }),
+      ),
+    ).toBe(true)
+    expect(
+      Maybe.equals(
+        Maybe.Just({ value: new Date(0) as unknown as number }),
+        Maybe.Just({ value: new Date(0) as unknown as number }),
+      ),
+    ).toBe(false)
+
+    const m = new Map([['k', 1]])
+    expect(
+      Maybe.equals(
+        Maybe.Just({ value: m as unknown as number }),
+        Maybe.Just({ value: m as unknown as number }),
+      ),
+    ).toBe(true)
+    expect(
+      Maybe.equals(
+        Maybe.Just({ value: new Map([['k', 1]]) as unknown as number }),
+        Maybe.Just({ value: new Map([['k', 1]]) as unknown as number }),
+      ),
+    ).toBe(false)
+  })
+
+  it('is symmetric', () => {
+    const a = Maybe.Just({ value: { x: 1, y: [2, 3] } as unknown as number })
+    const b = Maybe.Just({ value: { x: 1, y: [2, 3] } as unknown as number })
+    expect(Maybe.equals(a, b)).toBe(Maybe.equals(b, a))
+  })
+
+  it('handles self-referential cyclic structures without stack overflow', () => {
+    type Cyclic = { v: number; self?: Cyclic }
+    const a: Cyclic = { v: 1 }
+    a.self = a
+    const b: Cyclic = { v: 1 }
+    b.self = b
+    expect(
+      Maybe.equals(
+        Maybe.Just({ value: a as unknown as number }),
+        Maybe.Just({ value: b as unknown as number }),
+      ),
+    ).toBe(true)
+  })
+
+  it('detects field differences inside cyclic structures', () => {
+    type Cyclic = { v: number; self?: Cyclic }
+    const a: Cyclic = { v: 1 }
+    a.self = a
+    const b: Cyclic = { v: 2 }
+    b.self = b
+    expect(
+      Maybe.equals(
+        Maybe.Just({ value: a as unknown as number }),
+        Maybe.Just({ value: b as unknown as number }),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns false when one side has an extra own key beyond the spec', () => {
+    // deepEquals compares by own keys on both sides; a stray key on one side
+    // makes the key counts differ, so the values are unequal.
+    const a = Maybe.Just({ value: 42 })
+    const b = { ...a, bogus: 'extra' } as unknown as Maybe<number>
+    expect(Maybe.equals(a, b)).toBe(false)
+    expect(Maybe.equals(b, a)).toBe(false)
+  })
+
+  it('returns true when both sides share the same extra own key', () => {
+    // Symmetric sanity check: two runtime values with matching stray keys
+    // still compare equal. deepEquals is blind to the spec — it walks own keys.
+    const a = {
+      ...Maybe.Just({ value: 42 }),
+      extra: 'x',
+    } as unknown as Maybe<number>
+    const b = {
+      ...Maybe.Just({ value: 42 }),
+      extra: 'x',
+    } as unknown as Maybe<number>
+    expect(Maybe.equals(a, b)).toBe(true)
+  })
+
+  it('handles deeply nested non-cyclic structures without stack overflow', () => {
+    // Build a 1000-level linked list. deepEquals is recursive, so this
+    // exercises the recursion depth in a realistic direction.
+    type Node = { v: number; next: Node | null }
+    const build = (n: number): Node => {
+      let node: Node = { v: 0, next: null }
+      for (let i = 1; i < n; i++) node = { v: i, next: node }
+      return node
+    }
+    const a = build(1000)
+    const b = build(1000)
+    expect(
+      Maybe.equals(
+        Maybe.Just({ value: a as unknown as number }),
+        Maybe.Just({ value: b as unknown as number }),
+      ),
+    ).toBe(true)
+    // And detect a difference deep in the chain.
+    const c = build(1000)
+    let tail: Node | null = c
+    while (tail?.next) tail = tail.next
+    // mutate the deepest node
+    if (tail) tail.v = 999
+    expect(
+      Maybe.equals(
+        Maybe.Just({ value: a as unknown as number }),
+        Maybe.Just({ value: c as unknown as number }),
+      ),
+    ).toBe(false)
+  })
+
+  it('handles mutually-referential cycles', () => {
+    type Node = { v: number; next?: Node }
+    const a1: Node = { v: 1 }
+    const a2: Node = { v: 2 }
+    a1.next = a2
+    a2.next = a1
+    const b1: Node = { v: 1 }
+    const b2: Node = { v: 2 }
+    b1.next = b2
+    b2.next = b1
+    expect(
+      Maybe.equals(
+        Maybe.Just({ value: a1 as unknown as number }),
+        Maybe.Just({ value: b1 as unknown as number }),
+      ),
+    ).toBe(true)
+  })
+})
+
+// ===========================================================================
+// parse
+// ===========================================================================
+
+describe('parse', () => {
+  it('returns the value when discriminant matches a known tag', () => {
+    const x = Maybe.parse({ tag: 'Just', value: 42 })
+    expect(x).toEqual({ tag: 'Just', value: 42 })
+  })
+
+  it('parses nullary members', () => {
+    expect(Maybe.parse({ tag: 'Nothing' })).toEqual({ tag: 'Nothing' })
+  })
+
+  it('returns undefined for unknown tags', () => {
+    expect(Maybe.parse({ tag: 'Bogus' })).toBeUndefined()
+  })
+
+  it('returns undefined for missing discriminant', () => {
+    expect(Maybe.parse({ value: 42 })).toBeUndefined()
+  })
+
+  it('returns undefined for non-objects', () => {
+    expect(Maybe.parse(null)).toBeUndefined()
+    expect(Maybe.parse(undefined)).toBeUndefined()
+    expect(Maybe.parse(42)).toBeUndefined()
+    expect(Maybe.parse('Just')).toBeUndefined()
+  })
+
+  it('uses the custom discriminant key', () => {
+    expect(CounterAction.parse({ type: 'Increment', amount: 1 })).toEqual({
+      type: 'Increment',
+      amount: 1,
+    })
+    expect(CounterAction.parse({ tag: 'Increment', amount: 1 })).toBeUndefined()
+  })
+
+  it('is shallow — does not validate field shapes', () => {
+    // Documented limitation: only the tag is checked
+    const result = Maybe.parse({ tag: 'Just' /* missing value */ })
+    expect(result).toEqual({ tag: 'Just' })
+  })
+
+  it('returns undefined for arrays', () => {
+    expect(Maybe.parse([])).toBeUndefined()
+    expect(Maybe.parse(['Just', 42])).toBeUndefined()
+  })
+
+  it('returns undefined for non-string discriminant values', () => {
+    expect(Maybe.parse({ tag: 42 })).toBeUndefined()
+    expect(Maybe.parse({ tag: null })).toBeUndefined()
+    expect(Maybe.parse({ tag: { nested: 'Just' } })).toBeUndefined()
+  })
+
+  it('rejects prototype-pollution: inherited tag must not count', () => {
+    // Object with `tag` on prototype only — should NOT pass parse
+    const malicious = Object.create({ tag: 'Just', value: 42 })
+    expect(Maybe.parse(malicious)).toBeUndefined()
+  })
+
+  it('accepts Object.create(null) with own discriminant key', () => {
+    const bare = Object.create(null)
+    bare.tag = 'Just'
+    bare.value = 42
+    expect(Maybe.parse(bare)).toBe(bare)
+  })
+
+  it('round-trips: parse(constructed) returns the same reference', () => {
+    const m = Maybe.Just({ value: 42 })
+    expect(Maybe.parse(m)).toBe(m)
+  })
+
+  it('round-trips through JSON', () => {
+    const m = Maybe.Just({ value: 42 })
+    const roundTripped = Maybe.parse(JSON.parse(JSON.stringify(m)))
+    expect(roundTripped).toEqual(m)
+    expect(Maybe.equals(roundTripped as typeof m, m)).toBe(true)
+  })
+})
+
+// ===========================================================================
+// Property-based: dogfood the library's own fast-check integration
+// ===========================================================================
+
+describe('property tests (named)', () => {
+  const arbMaybe = mkArbitrary<Maybe<number>>({
+    Just: { value: fc.integer() },
+    Nothing: {},
+  })
+
+  it('equals is reflexive for all generated values', () => {
+    fc.assert(fc.property(arbMaybe, m => Maybe.equals(m, m)))
+  })
+
+  it('equals is symmetric for independently-generated equal values', () => {
+    fc.assert(
+      fc.property(arbMaybe, m => {
+        // Clone via JSON to get a structurally equal but distinct value
+        const clone = JSON.parse(JSON.stringify(m)) as typeof m
+        return Maybe.equals(m, clone) === Maybe.equals(clone, m)
+      }),
+    )
+  })
+
+  it('parse accepts every generated value', () => {
+    fc.assert(fc.property(arbMaybe, m => Maybe.parse(m) !== undefined))
+  })
+
+  it('show produces a non-empty string for every generated value', () => {
+    fc.assert(
+      fc.property(
+        arbMaybe,
+        m => typeof Maybe.show(m) === 'string' && Maybe.show(m).length > 0,
+      ),
+    )
+  })
+
+  it('show starts with a known tag', () => {
+    fc.assert(
+      fc.property(arbMaybe, m => {
+        const s = Maybe.show(m)
+        return Maybe.tags.some(tag => s === tag || s.startsWith(`${tag}(`))
+      }),
+    )
+  })
+
+  it('every generated value passes memberOfUnion guard', () => {
+    fc.assert(fc.property(arbMaybe, m => Maybe.is.memberOfUnion(m)))
+  })
+})

--- a/test/positional/features.test.ts
+++ b/test/positional/features.test.ts
@@ -1,0 +1,366 @@
+import fc from 'fast-check'
+import { describe, expect, it } from 'vitest'
+import { mkArbitrary } from '../../src/fast-check'
+import type {
+  MkData,
+  TaggedLambda0,
+  TaggedLambda1,
+  TaggedLambda2,
+} from '../../src/positional'
+import { mkTaggedUnion, mkTaggedUnionCustom } from '../../src/positional'
+
+// ===========================================================================
+// Setup
+// ===========================================================================
+
+type Nothing = { readonly tag: 'Nothing' }
+type Just<A> = { readonly tag: 'Just'; readonly value: A }
+type Maybe<A> = Just<A> | Nothing
+
+interface MaybeLambda extends TaggedLambda1 {
+  readonly type: Maybe<this['A']>
+  readonly data: MkData<this['type']>
+}
+
+const Maybe = mkTaggedUnion<MaybeLambda>()({ Just: ['value'], Nothing: [] })
+
+type Failure<E> = { readonly tag: 'Failure'; readonly error: E }
+type Success<A> = { readonly tag: 'Success'; readonly value: A }
+type Result<E, A> = Success<A> | Failure<E>
+
+interface ResultLambda extends TaggedLambda2 {
+  readonly type: Result<this['E'], this['A']>
+  readonly data: MkData<this['type']>
+}
+
+const Result = mkTaggedUnion<ResultLambda>()({
+  Success: ['value'],
+  Failure: ['error'],
+})
+
+// A two-field variant to verify positional ordering in `show`.
+type Emit<S, A> = {
+  readonly tag: 'Emit'
+  readonly state: S
+  readonly value: A
+}
+type End = { readonly tag: 'End' }
+type Stream<S, A> = Emit<S, A> | End
+
+interface StreamLambda extends TaggedLambda2 {
+  readonly type: Stream<this['E'], this['A']>
+  readonly data: MkData<this['type']>
+}
+
+const Stream = mkTaggedUnion<StreamLambda>()({
+  Emit: ['state', 'value'],
+  End: [],
+})
+
+type Increment = { readonly type: 'Increment'; readonly amount: number }
+type Reset = { readonly type: 'Reset' }
+type CounterAction = Increment | Reset
+
+interface CounterActionLambda extends TaggedLambda0 {
+  readonly type: CounterAction
+  readonly data: MkData<this['type'], 'type'>
+}
+
+const CounterAction = mkTaggedUnionCustom<CounterActionLambda>()('type', {
+  Increment: ['amount'],
+  Reset: [],
+})
+
+// ===========================================================================
+// tags
+// ===========================================================================
+
+describe('tags', () => {
+  it('returns all member tag strings', () => {
+    expect(Maybe.tags).toEqual(['Just', 'Nothing'])
+    expect(Stream.tags).toEqual(['Emit', 'End'])
+    expect(CounterAction.tags).toEqual(['Increment', 'Reset'])
+  })
+
+  it('is frozen', () => {
+    expect(Object.isFrozen(Stream.tags)).toBe(true)
+  })
+
+  it('throws on mutation attempt', () => {
+    expect(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: exercising runtime freeze
+      ;(Stream.tags as any).push('Bogus')
+    }).toThrow(TypeError)
+  })
+
+  it('returns stable reference', () => {
+    expect(Stream.tags).toBe(Stream.tags)
+  })
+})
+
+// ===========================================================================
+// show
+// ===========================================================================
+
+describe('show (positional)', () => {
+  it('formats nullary members as just the tag', () => {
+    expect(Maybe.show(Maybe.Nothing)).toBe('Nothing')
+    expect(Stream.show(Stream.End)).toBe('End')
+  })
+
+  it('formats single-field members with positional value', () => {
+    expect(Maybe.show(Maybe.Just(42))).toBe('Just(42)')
+    expect(Maybe.show(Maybe.Just('hi'))).toBe('Just("hi")')
+  })
+
+  it('formats multi-field members in declared order', () => {
+    expect(Stream.show(Stream.Emit('s', 42))).toBe('Emit("s", 42)')
+  })
+
+  it('formats nested plain objects recursively', () => {
+    expect(Maybe.show(Maybe.Just({ a: 1, b: [2, 3] }))).toBe(
+      'Just({ a: 1, b: [2, 3] })',
+    )
+  })
+
+  it('renders a tagged union nested inside another as a plain object', () => {
+    // Nested member has no prototype distinction — formatValue sees it as plain
+    // and renders its own `tag` key verbatim.
+    expect(Maybe.show(Maybe.Just(Maybe.Just(1) as unknown as number))).toBe(
+      'Just({ tag: "Just", value: 1 })',
+    )
+    expect(
+      Maybe.show(Maybe.Just(Stream.Emit('s', 42) as unknown as number)),
+    ).toBe('Just({ tag: "Emit", state: "s", value: 42 })')
+  })
+
+  it('handles custom discriminant key', () => {
+    expect(CounterAction.show(CounterAction.Increment(3))).toBe('Increment(3)')
+    expect(CounterAction.show(CounterAction.Reset)).toBe('Reset')
+  })
+
+  it('formats booleans and null', () => {
+    expect(Maybe.show(Maybe.Just(true as unknown as number))).toBe('Just(true)')
+    expect(Maybe.show(Maybe.Just(null as unknown as number))).toBe('Just(null)')
+  })
+
+  it('formats arrays with spaces', () => {
+    expect(Maybe.show(Maybe.Just([1, 2, 3] as unknown as number))).toBe(
+      'Just([1, 2, 3])',
+    )
+  })
+
+  it('uses spec field order (not insertion order) when values arrive via spread', () => {
+    // Directly construct an object with keys in the opposite order, then show.
+    // show should still render in spec order: state, value
+    const weird = { tag: 'Emit' as const, value: 42, state: 's' }
+    expect(Stream.show(weird)).toBe('Emit("s", 42)')
+  })
+
+  it('omits fields present on the runtime value but missing from the spec', () => {
+    // Defensive: if a value has extra keys, show only emits the declared ones
+    const extra = {
+      tag: 'Emit' as const,
+      state: 's',
+      value: 42,
+      bogus: 'ignored',
+    } as unknown as Stream<string, number>
+    expect(Stream.show(extra)).toBe('Emit("s", 42)')
+  })
+
+  it('renders Date/RegExp/Error via rich formatter', () => {
+    expect(
+      Maybe.show(
+        Maybe.Just(new Date('2024-01-01T00:00:00.000Z') as unknown as number),
+      ),
+    ).toBe('Just(Date("2024-01-01T00:00:00.000Z"))')
+    expect(Maybe.show(Maybe.Just(/abc/i as unknown as number))).toBe(
+      'Just(/abc/i)',
+    )
+    expect(Maybe.show(Maybe.Just(new Error('oops') as unknown as number))).toBe(
+      'Just(Error("oops"))',
+    )
+  })
+
+  it('renders Map and Set', () => {
+    expect(Maybe.show(Maybe.Just(new Set([1, 2]) as unknown as number))).toBe(
+      'Just(Set(1, 2))',
+    )
+    expect(
+      Maybe.show(Maybe.Just(new Map([['k', 1]]) as unknown as number)),
+    ).toBe('Just(Map("k" => 1))')
+  })
+
+  it('renders bigint, symbol, function', () => {
+    expect(Maybe.show(Maybe.Just(42n as unknown as number))).toBe('Just(42n)')
+    expect(Maybe.show(Maybe.Just(Symbol('x') as unknown as number))).toBe(
+      'Just(Symbol(x))',
+    )
+    expect(Maybe.show(Maybe.Just(function foo() {} as unknown as number))).toBe(
+      'Just([Function: foo])',
+    )
+  })
+
+  it('renders class instances with constructor name', () => {
+    class Point {
+      x: number
+      y: number
+      constructor(x: number, y: number) {
+        this.x = x
+        this.y = y
+      }
+    }
+    expect(Maybe.show(Maybe.Just(new Point(1, 2) as unknown as number))).toBe(
+      'Just(Point { x: 1, y: 2 })',
+    )
+  })
+
+  it('marks cyclic references with [Circular]', () => {
+    const cyclic: { self?: unknown } = {}
+    cyclic.self = cyclic
+    expect(Maybe.show(Maybe.Just(cyclic as unknown as number))).toBe(
+      'Just({ self: [Circular] })',
+    )
+  })
+})
+
+// ===========================================================================
+// equals
+// ===========================================================================
+
+describe('equals', () => {
+  it('returns true for structurally identical members', () => {
+    expect(Maybe.equals(Maybe.Just(42), Maybe.Just(42))).toBe(true)
+    expect(Maybe.equals(Maybe.Nothing, Maybe.Nothing)).toBe(true)
+  })
+
+  it('returns false for different discriminants', () => {
+    expect(Maybe.equals(Maybe.Just(42), Maybe.Nothing)).toBe(false)
+  })
+
+  it('returns false for different field values', () => {
+    expect(Maybe.equals(Maybe.Just(42), Maybe.Just(43))).toBe(false)
+  })
+
+  it('compares nested objects structurally', () => {
+    const a = Maybe.Just({ a: 1, b: [1, 2, 3] })
+    const b = Maybe.Just({ a: 1, b: [1, 2, 3] })
+    expect(Maybe.equals(a, b)).toBe(true)
+  })
+
+  it('compares multi-field members positionally', () => {
+    expect(Stream.equals(Stream.Emit('s', 42), Stream.Emit('s', 42))).toBe(true)
+    expect(Stream.equals(Stream.Emit('s', 42), Stream.Emit('s', 43))).toBe(
+      false,
+    )
+  })
+
+  it('handles Result with error/value fields', () => {
+    expect(Result.equals(Result.Success(1), Result.Failure('e'))).toBe(false)
+    expect(Result.equals(Result.Failure('e'), Result.Failure('e'))).toBe(true)
+  })
+})
+
+// ===========================================================================
+// parse
+// ===========================================================================
+
+describe('parse', () => {
+  it('returns the value when discriminant matches a known tag', () => {
+    const x = Maybe.parse({ tag: 'Just', value: 42 })
+    expect(x).toEqual({ tag: 'Just', value: 42 })
+  })
+
+  it('parses nullary members', () => {
+    expect(Maybe.parse({ tag: 'Nothing' })).toEqual({ tag: 'Nothing' })
+  })
+
+  it('returns undefined for unknown tags', () => {
+    expect(Maybe.parse({ tag: 'Bogus' })).toBeUndefined()
+  })
+
+  it('returns undefined for missing discriminant', () => {
+    expect(Maybe.parse({ value: 42 })).toBeUndefined()
+  })
+
+  it('returns undefined for non-objects', () => {
+    expect(Maybe.parse(null)).toBeUndefined()
+    expect(Maybe.parse(undefined)).toBeUndefined()
+    expect(Maybe.parse(42)).toBeUndefined()
+  })
+
+  it('uses the custom discriminant key', () => {
+    expect(CounterAction.parse({ type: 'Increment', amount: 1 })).toEqual({
+      type: 'Increment',
+      amount: 1,
+    })
+    expect(CounterAction.parse({ tag: 'Increment', amount: 1 })).toBeUndefined()
+  })
+
+  it('is shallow — does not validate field shapes', () => {
+    const result = Maybe.parse({ tag: 'Just' /* missing value */ })
+    expect(result).toEqual({ tag: 'Just' })
+  })
+
+  it('returns undefined for arrays', () => {
+    expect(Maybe.parse([])).toBeUndefined()
+    expect(Maybe.parse(['Just', 42])).toBeUndefined()
+  })
+
+  it('rejects inherited discriminant (prototype pollution guard)', () => {
+    const malicious = Object.create({ tag: 'Just', value: 42 })
+    expect(Maybe.parse(malicious)).toBeUndefined()
+  })
+
+  it('rejects non-string discriminant values', () => {
+    expect(Maybe.parse({ tag: 42 })).toBeUndefined()
+    expect(Maybe.parse({ tag: true })).toBeUndefined()
+  })
+
+  it('accepts Object.create(null) with own discriminant', () => {
+    const bare = Object.create(null)
+    bare.tag = 'Just'
+    expect(Maybe.parse(bare)).toBe(bare)
+  })
+})
+
+// ===========================================================================
+// Property-based: dogfood the library's own fast-check integration
+// ===========================================================================
+
+describe('property tests (positional)', () => {
+  const arbStream = mkArbitrary<Stream<string, number>>({
+    Emit: { state: fc.string(), value: fc.integer() },
+    End: {},
+  })
+
+  it('equals is reflexive', () => {
+    fc.assert(fc.property(arbStream, s => Stream.equals(s, s)))
+  })
+
+  it('equals is symmetric on JSON clones', () => {
+    fc.assert(
+      fc.property(arbStream, s => {
+        const clone = JSON.parse(JSON.stringify(s)) as typeof s
+        return Stream.equals(s, clone) === Stream.equals(clone, s)
+      }),
+    )
+  })
+
+  it('parse accepts every generated value', () => {
+    fc.assert(fc.property(arbStream, s => Stream.parse(s) !== undefined))
+  })
+
+  it('show produces a string starting with a known tag', () => {
+    fc.assert(
+      fc.property(arbStream, s => {
+        const str = Stream.show(s)
+        return Stream.tags.some(tag => str === tag || str.startsWith(`${tag}(`))
+      }),
+    )
+  })
+
+  it('every generated value passes memberOfUnion guard', () => {
+    fc.assert(fc.property(arbStream, s => Stream.is.memberOfUnion(s)))
+  })
+})


### PR DESCRIPTION
## Summary

Expands each tagged union constructor with a set of runtime utilities shared between the named and positional styles, plus a new optional `tagged-ts/fast-check` subpath for property-based testing.

### New utilities (both styles)

- **`tags`** — frozen array of member tag strings; stable reference; refuses mutation at runtime.
- **`show`** — rich pretty-printer that formats:
  - primitives (including `-0`, `bigint`, `symbol`, `function`)
  - built-ins: `Date`, `RegExp`, `Error`, `Map`, `Set`
  - arrays, plain objects, and class instances (rendered with the constructor name)
  - cyclic references as `[Circular]`
  - positional: renders fields in spec order regardless of runtime key order
  - named: renders fields by name in insertion order
- **`equals`** — cycle-safe structural equality via coinductive pair tracking (`WeakMap<object, WeakSet<object>>`). Handles self-referential and mutually-referential cycles, and deep (1000+ level) non-cyclic structures without stack overflow.
- **`parse`** — hardened shallow decoder:
  - rejects non-objects, arrays, missing discriminant, non-string discriminant, unknown tags
  - uses `Object.hasOwn` so inherited (prototype-pollution) tags do not slip through
  - accepts `Object.create(null)` with an own discriminant

### New subpath: `tagged-ts/fast-check`

- `mkArbitrary<U>(spec)` and `mkArbitraryCustom<U, DK>(dk, spec)` build a `fast-check` `Arbitrary<U>` from a record of per-member field arbitraries.
- Style-agnostic: works for both named and positional unions since the generated value shape is identical.
- `fast-check` is an **optional** peer dependency (`^3 || ^4`) declared via `peerDependenciesMeta`. The subpath is only loaded when explicitly imported, so existing consumers pay nothing.

### Internal

- All four utilities live in `src/internal/shared.ts` and are re-exposed through each style's `mkTaggedUnion` / `mkTaggedUnionCustom` return values. Single source of truth for behavior.
- Rollup config adds a `fast-check` entry with `external: ['fast-check']` so the peer isn't bundled.
- `package.json` adds the `./fast-check` export with both ESM and CJS conditions, plus a `.d.cts` copy in the build step.

### Tests

**414 tests passing** across 9 files. Coverage includes:

- All primitive / built-in / class / cyclic / deep formatting cases for `show` in both styles
- Cyclic `equals` (self-referential, field differences inside cycles, mutually-referential cycles, deep non-cyclic 1000-node lists)
- `equals` sensitivity to extra own keys (asymmetric → unequal, matching → equal)
- `parse` hardening (prototype pollution, non-string tags, arrays, `Object.create(null)`)
- Property tests dogfooding `mkArbitrary`: reflexivity, symmetry under JSON clone, `parse` accepts every generated value, `show` starts with a known tag, every value passes `is.memberOfUnion`
- Round-trip integration: generated values parse successfully and survive JSON round-trip under `equals`
- `mkArbitrary` error cases (empty spec throws; partial spec documented as TypeScript-level guarantee)

### Docs

README gains:
- a "Utilities" section covering `tags` / `show` / `equals` / `parse` with usage examples
- a "Property-Based Testing" section showing `mkArbitrary` usage
- a new `fast-check` row in the Modules table