### PR TITLE
Add examples/ directory with 6 runnable snippets

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -46,6 +46,6 @@
     }
   },
   "files": {
-    "includes": ["src/**", "test/**", "*.ts", "*.mjs", "*.json"]
+    "includes": ["src/**", "test/**", "examples/**", "*.ts", "*.mjs", "*.json"]
   }
 }

--- a/examples/01-maybe.ts
+++ b/examples/01-maybe.ts
@@ -1,0 +1,93 @@
+/**
+ * Example: Maybe<A> — the classic optional value.
+ *
+ * Run with:  npx tsx examples/01-maybe.ts
+ *
+ * Demonstrates:
+ *   - Declaring a tagged union with arity-1 (Maybe<A>)
+ *   - Named (object-style) constructors
+ *   - Exhaustive pattern matching with `match`
+ *   - Widened return types via `matchW`
+ *   - Partial matching with default via `matchOr`
+ *   - Pretty-printing via `show` and iterating `tags`
+ *
+ * In a real project, you would import from the published package:
+ *   import { mkTaggedUnion } from 'tagged-ts/named'
+ * Here we use a relative path because this file lives inside the repo.
+ */
+
+import type { MkData, TaggedLambda1 } from '../src/named'
+import { mkTaggedUnion } from '../src/named'
+
+// ---------------------------------------------------------------------------
+// 1. Declare the union type
+// ---------------------------------------------------------------------------
+
+type Nothing = { readonly tag: 'Nothing' }
+type Just<A> = { readonly tag: 'Just'; readonly value: A }
+type Maybe<A> = Just<A> | Nothing
+
+// The Lambda interface lets the library thread the `A` type parameter
+// through the generated constructors, guards, and match functions.
+interface MaybeLambda extends TaggedLambda1 {
+  readonly type: Maybe<this['A']>
+  readonly data: MkData<this['type']>
+}
+
+// ---------------------------------------------------------------------------
+// 2. Generate constructors and utilities
+// ---------------------------------------------------------------------------
+
+const Maybe = mkTaggedUnion<MaybeLambda>({
+  Just: true, // has fields beyond the discriminant
+  Nothing: false, // no fields beyond the discriminant
+})
+
+// ---------------------------------------------------------------------------
+// 3. Build values
+// ---------------------------------------------------------------------------
+
+const aJust: Maybe<number> = Maybe.Just({ value: 42 })
+const aNothing: Maybe<number> = Maybe.Nothing // nullary — used like a constant
+
+// ---------------------------------------------------------------------------
+// 4. Exhaustive `match` — all cases must be handled, same return type
+// ---------------------------------------------------------------------------
+
+const describe = (m: Maybe<number>): string =>
+  Maybe.match(m, {
+    Just: ({ value }) => `got ${value}`,
+    Nothing: () => 'got nothing',
+  })
+
+console.log(describe(aJust)) // got 42
+console.log(describe(aNothing)) // got nothing
+
+// ---------------------------------------------------------------------------
+// 5. `matchW` — handlers may return different types
+// ---------------------------------------------------------------------------
+
+const widened = Maybe.matchW(aJust, {
+  Just: ({ value }) => value, // number
+  Nothing: () => 'empty' as const, // 'empty'
+})
+// widened has type `number | 'empty'`
+console.log('matchW:', widened)
+
+// ---------------------------------------------------------------------------
+// 6. `matchOr` — handle only the cases you care about, default covers the rest
+// ---------------------------------------------------------------------------
+
+const safeGet = (m: Maybe<number>, fallback: number): number =>
+  Maybe.matchOr(m, { Just: ({ value }) => value }, () => fallback)
+
+console.log('safeGet(Just 42, 0) =', safeGet(aJust, 0)) // 42
+console.log('safeGet(Nothing, 0) =', safeGet(aNothing, 0)) // 0
+
+// ---------------------------------------------------------------------------
+// 7. v0.6 utilities: `show` and `tags`
+// ---------------------------------------------------------------------------
+
+console.log('show:', Maybe.show(aJust)) // Just({ value: 42 })
+console.log('show:', Maybe.show(aNothing)) // Nothing
+console.log('tags:', Maybe.tags) // ['Just', 'Nothing']

--- a/examples/02-result.ts
+++ b/examples/02-result.ts
@@ -1,0 +1,128 @@
+/**
+ * Example: Result<E, A> — success / failure for error handling.
+ *
+ * Run with:  npx tsx examples/02-result.ts
+ *
+ * Demonstrates:
+ *   - Arity-2 tagged unions (two type parameters: error and value)
+ *   - Modeling operations that can fail without throwing
+ *   - Chaining Results through a pipeline with `matchW`
+ *   - Using `matchOr` for a fallback on the error path
+ *   - Parsing JSON safely into a typed Result
+ */
+
+import type { MkData, TaggedLambda2 } from '../src/named'
+import { mkTaggedUnion } from '../src/named'
+
+// ---------------------------------------------------------------------------
+// 1. Declare Result<E, A>
+// ---------------------------------------------------------------------------
+
+type Failure<E> = { readonly tag: 'Failure'; readonly error: E }
+type Success<A> = { readonly tag: 'Success'; readonly value: A }
+type Result<E, A> = Success<A> | Failure<E>
+
+interface ResultLambda extends TaggedLambda2 {
+  readonly type: Result<this['E'], this['A']>
+  readonly data: MkData<this['type']>
+}
+
+const Result = mkTaggedUnion<ResultLambda>({ Success: true, Failure: true })
+
+// ---------------------------------------------------------------------------
+// 2. Model a parse pipeline that can fail at multiple points
+// ---------------------------------------------------------------------------
+
+type ParseError =
+  | { readonly kind: 'InvalidJSON'; readonly source: string }
+  | { readonly kind: 'MissingField'; readonly field: string }
+  | {
+      readonly kind: 'WrongType'
+      readonly field: string
+      readonly expected: string
+    }
+
+type User = { readonly name: string; readonly age: number }
+
+const parseJSON = (source: string): Result<ParseError, unknown> => {
+  try {
+    return Result.Success({ value: JSON.parse(source) as unknown })
+  } catch {
+    return Result.Failure({ error: { kind: 'InvalidJSON', source } })
+  }
+}
+
+const toUser = (raw: unknown): Result<ParseError, User> => {
+  if (typeof raw !== 'object' || raw === null) {
+    return Result.Failure({
+      error: { kind: 'WrongType', field: '(root)', expected: 'object' },
+    })
+  }
+  const obj = raw as Record<string, unknown>
+  if (!('name' in obj)) {
+    return Result.Failure({
+      error: { kind: 'MissingField', field: 'name' },
+    })
+  }
+  if (typeof obj.name !== 'string') {
+    return Result.Failure({
+      error: { kind: 'WrongType', field: 'name', expected: 'string' },
+    })
+  }
+  if (!('age' in obj)) {
+    return Result.Failure({ error: { kind: 'MissingField', field: 'age' } })
+  }
+  if (typeof obj.age !== 'number') {
+    return Result.Failure({
+      error: { kind: 'WrongType', field: 'age', expected: 'number' },
+    })
+  }
+  return Result.Success({ value: { name: obj.name, age: obj.age } })
+}
+
+// ---------------------------------------------------------------------------
+// 3. Chain two steps with `matchW` — carry the Failure through unchanged
+// ---------------------------------------------------------------------------
+
+const parseUser = (source: string): Result<ParseError, User> =>
+  Result.matchW(parseJSON(source), {
+    Success: ({ value }) => toUser(value),
+    Failure: (f): Result<ParseError, User> => f,
+  })
+
+// ---------------------------------------------------------------------------
+// 4. Render outcomes
+// ---------------------------------------------------------------------------
+
+const render = (r: Result<ParseError, User>): string =>
+  Result.match(r, {
+    Success: ({ value }) => `OK: ${value.name} (${value.age})`,
+    Failure: ({ error }) => {
+      switch (error.kind) {
+        case 'InvalidJSON':
+          return `ERR: could not parse JSON: ${error.source}`
+        case 'MissingField':
+          return `ERR: missing field "${error.field}"`
+        case 'WrongType':
+          return `ERR: field "${error.field}" should be ${error.expected}`
+      }
+    },
+  })
+
+console.log(render(parseUser('{"name":"Ada","age":37}'))) // OK: Ada (37)
+console.log(render(parseUser('not json'))) // InvalidJSON
+console.log(render(parseUser('{"age":37}'))) // MissingField name
+console.log(render(parseUser('{"name":"Ada","age":"old"}'))) // WrongType age
+
+// ---------------------------------------------------------------------------
+// 5. `matchOr` — fall back to a default on any failure
+// ---------------------------------------------------------------------------
+
+const getNameOr = (r: Result<ParseError, User>, fallback: string): string =>
+  Result.matchOr(r, { Success: ({ value }) => value.name }, () => fallback)
+
+console.log(
+  'name or "anon":',
+  getNameOr(parseUser('{"name":"Ada","age":37}'), 'anon'),
+) // Ada
+console.log('name or "anon":', getNameOr(parseUser('not json'), 'anon')) // anon

--- a/examples/03-positional-tree.ts
+++ b/examples/03-positional-tree.ts
@@ -1,0 +1,102 @@
+/**
+ * Example: Tree<A> — recursive ADT with positional constructors.
+ *
+ * Run with:  npx tsx examples/03-positional-tree.ts
+ *
+ * Demonstrates:
+ *   - Positional constructor style: `Tree.Node(left, value, right)` rather
+ *     than `Tree.Node({ left, value, right })`
+ *   - A recursive tagged union (Tree<A> contains Tree<A>)
+ *   - Folding the structure via `match` to compute sum, size, and depth
+ *   - In-order traversal as another `match` fold
+ *
+ * Positional style is handy when the field names add no real information
+ * (e.g. a binary tree's left / value / right). Named style is usually
+ * better when the field names document intent (see 01-maybe / 02-result).
+ */
+
+import type { MkData, TaggedLambda1 } from '../src/positional'
+import { mkTaggedUnion } from '../src/positional'
+
+// ---------------------------------------------------------------------------
+// 1. Declare Tree<A>
+// ---------------------------------------------------------------------------
+
+type Leaf = { readonly tag: 'Leaf' }
+type Node<A> = {
+  readonly tag: 'Node'
+  readonly left: Tree<A>
+  readonly value: A
+  readonly right: Tree<A>
+}
+type Tree<A> = Leaf | Node<A>
+
+interface TreeLambda extends TaggedLambda1 {
+  readonly type: Tree<this['A']>
+  readonly data: MkData<this['type']>
+}
+
+// Positional constructors: the second call takes a map of field-name tuples
+// giving the positional argument order for each non-nullary member.
+const Tree = mkTaggedUnion<TreeLambda>()({
+  Leaf: [],
+  Node: ['left', 'value', 'right'],
+})
+
+// ---------------------------------------------------------------------------
+// 2. Build a small tree
+// ---------------------------------------------------------------------------
+
+//         5
+//        / \
+//       3   8
+//      / \   \
+//     1   4   9
+const leaf: Tree<number> = Tree.Leaf
+const tree: Tree<number> = Tree.Node(
+  Tree.Node(Tree.Node(leaf, 1, leaf), 3, Tree.Node(leaf, 4, leaf)),
+  5,
+  Tree.Node(leaf, 8, Tree.Node(leaf, 9, leaf)),
+)
+
+// ---------------------------------------------------------------------------
+// 3. Fold over the tree via recursive `match`
+// ---------------------------------------------------------------------------
+
+const sum = (t: Tree<number>): number =>
+  Tree.match(t, {
+    Leaf: () => 0,
+    Node: ({ left, value, right }) => sum(left) + value + sum(right),
+  })
+
+const size = <A>(t: Tree<A>): number =>
+  Tree.match(t, {
+    Leaf: () => 0,
+    Node: ({ left, right }) => 1 + size(left) + size(right),
+  })
+
+const depth = <A>(t: Tree<A>): number =>
+  Tree.match(t, {
+    Leaf: () => 0,
+    Node: ({ left, right }) => 1 + Math.max(depth(left), depth(right)),
+  })
+
+console.log('sum  =', sum(tree)) // 30
+console.log('size =', size(tree)) // 6
+console.log('depth=', depth(tree)) // 3
+
+// ---------------------------------------------------------------------------
+// 4. In-order traversal via `match`
+// ---------------------------------------------------------------------------
+
+const inorder = <A>(t: Tree<A>): A[] =>
+  Tree.match(t, {
+    Leaf: () => [],
+    Node: ({ left, value, right }) => [
+      ...inorder(left),
+      value,
+      ...inorder(right),
+    ],
+  })
+
+console.log('inorder:', inorder(tree)) // [1, 3, 4, 5, 8, 9]

--- a/examples/04-state-machine.ts
+++ b/examples/04-state-machine.ts
@@ -1,0 +1,116 @@
+/**
+ * Example: RequestState — an async request state machine.
+ *
+ * Run with:  npx tsx examples/04-state-machine.ts
+ *
+ * Demonstrates:
+ *   - Using a tagged union as a finite-state machine
+ *   - Custom discriminant key (`state` instead of `tag`) via `mkTaggedUnionCustom`
+ *   - Exhaustive transitions via `match`
+ *   - Guarded access to state-specific fields via `is.X`
+ *
+ * States:
+ *   Idle ─► Loading ─► Success (with data)
+ *               └────► Failure (with error)
+ *   Success/Failure ─► Idle (reset)
+ */
+
+import type { MkData, TaggedLambda1 } from '../src/named'
+import { mkTaggedUnionCustom } from '../src/named'
+
+// ---------------------------------------------------------------------------
+// 1. Declare the state machine
+// ---------------------------------------------------------------------------
+
+type Idle = { readonly state: 'Idle' }
+type Loading = { readonly state: 'Loading'; readonly startedAt: number }
+type Success<A> = { readonly state: 'Success'; readonly data: A }
+type Failure = { readonly state: 'Failure'; readonly message: string }
+type RequestState<A> = Idle | Loading | Success<A> | Failure
+
+interface RequestStateLambda extends TaggedLambda1 {
+  readonly type: RequestState<this['A']>
+  readonly data: MkData<this['type'], 'state'>
+}
+
+const RequestState = mkTaggedUnionCustom<RequestStateLambda>()('state', {
+  Idle: false,
+  Loading: true,
+  Success: true,
+  Failure: true,
+})
+
+// ---------------------------------------------------------------------------
+// 2. Pure transition functions — each returns the next state
+// ---------------------------------------------------------------------------
+
+const start = <A>(s: RequestState<A>): RequestState<A> =>
+  RequestState.match(s, {
+    Idle: () => RequestState.Loading({ startedAt: Date.now() }),
+    // Already running — starting again would lose the startedAt timestamp.
+    Loading: x => x,
+    // Starting over from a terminal state is allowed.
+    Success: () => RequestState.Loading({ startedAt: Date.now() }),
+    Failure: () => RequestState.Loading({ startedAt: Date.now() }),
+  })
+
+const resolve = <A>(s: RequestState<A>, data: A): RequestState<A> =>
+  RequestState.match(s, {
+    // Only a Loading request can resolve; anything else is ignored.
+    Loading: () => RequestState.Success({ data }),
+    Idle: x => x,
+    Success: x => x,
+    Failure: x => x,
+  })
+
+const reject = <A>(s: RequestState<A>, message: string): RequestState<A> =>
+  RequestState.match(s, {
+    Loading: () => RequestState.Failure({ message }),
+    Idle: x => x,
+    Success: x => x,
+    Failure: x => x,
+  })
+
+const reset = <A>(_s: RequestState<A>): RequestState<A> => RequestState.Idle
+
+// ---------------------------------------------------------------------------
+// 3. Render a state
+// ---------------------------------------------------------------------------
+
+const render = <A>(s: RequestState<A>): string =>
+  RequestState.match(s, {
+    Idle: () => '[idle]',
+    Loading: ({ startedAt }) => `[loading since ${startedAt}]`,
+    Success: ({ data }) => `[success: ${JSON.stringify(data)}]`,
+    Failure: ({ message }) => `[failure: ${message}]`,
+  })
+
+// ---------------------------------------------------------------------------
+// 4. Drive the machine
+// ---------------------------------------------------------------------------
+
+const trace = <A>(label: string, s: RequestState<A>): RequestState<A> => {
+  console.log(label.padEnd(14), render(s))
+  return s
+}
+
+let s: RequestState<{ name: string }> = RequestState.Idle
+s = trace('initial', s)
+s = trace('start', start(s))
+s = trace('resolve', resolve(s, { name: 'Ada' }))
+s = trace('reset', reset(s))
+s = trace('start again', start(s))
+s = trace('reject', reject(s, 'timeout'))
+
+// ---------------------------------------------------------------------------
+// 5. Guarded access — `is.Success` narrows to the Success variant
+// ---------------------------------------------------------------------------
+
+if (RequestState.is.Success(s)) {
+  // TS knows s.data is of the inner type here
+  console.log('data:', s.data)
+} else if (RequestState.is.Failure(s)) {
+  console.log('final error:', s.message)
+} else {
+  console.log('still running or idle:', s.state)
+}

--- a/examples/05-parse-and-equals.ts
+++ b/examples/05-parse-and-equals.ts
@@ -1,0 +1,126 @@
+/**
+ * Example: parse + equals for form field state hydration and dirty-check.
+ *
+ * Run with:  npx tsx examples/05-parse-and-equals.ts
+ *
+ * Demonstrates the two v0.6 runtime utilities that are most useful when
+ * your union crosses a boundary:
+ *   - `parse`: takes `unknown` (e.g. something from localStorage, an HTTP
+ *     response, or a message event) and returns `Union | undefined`,
+ *     doing a shallow structural check on the discriminant only.
+ *   - `equals`: cycle-safe structural equality between two values of the
+ *     same union. Useful for dirty-check on form state.
+ *
+ * Scenario: a form field that round-trips through localStorage and gets
+ * compared against its original value to decide whether to enable a
+ * "Save" button.
+ */
+
+import type { MkData, TaggedLambda1 } from '../src/named'
+import { mkTaggedUnion } from '../src/named'
+
+// ---------------------------------------------------------------------------
+// 1. Field state: Empty | Typing (raw) | Valid (parsed) | Invalid (reason)
+// ---------------------------------------------------------------------------
+
+type Empty = { readonly tag: 'Empty' }
+type Typing = { readonly tag: 'Typing'; readonly raw: string }
+type Valid<A> = {
+  readonly tag: 'Valid'
+  readonly raw: string
+  readonly parsed: A
+}
+type Invalid = {
+  readonly tag: 'Invalid'
+  readonly raw: string
+  readonly reason: string
+}
+type Field<A> = Empty | Typing | Valid<A> | Invalid
+
+interface FieldLambda extends TaggedLambda1 {
+  readonly type: Field<this['A']>
+  readonly data: MkData<this['type']>
+}
+
+const Field = mkTaggedUnion<FieldLambda>({
+  Empty: false,
+  Typing: true,
+  Valid: true,
+  Invalid: true,
+})
+
+// ---------------------------------------------------------------------------
+// 2. A fake localStorage that forgets types across the boundary
+// ---------------------------------------------------------------------------
+
+const storage = new Map<string, string>()
+
+const save = <A>(key: string, f: Field<A>): void => {
+  storage.set(key, JSON.stringify(f))
+}
+
+// `parse` only validates the discriminant shape; the `parsed` payload is
+// still just `unknown` at runtime. It is up to the caller to narrow or
+// revalidate any inner data. For a well-known structural shape like
+// Field<number>, this is exactly the check we want at the boundary.
+const load = <A>(key: string): Field<A> | undefined => {
+  const raw = storage.get(key)
+  if (raw === undefined) return undefined
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+  return Field.parse(parsed) as Field<A> | undefined
+}
+
+// ---------------------------------------------------------------------------
+// 3. Round-trip some values through storage
+// ---------------------------------------------------------------------------
+
+const initial: Field<number> = Field.Valid({ raw: '42', parsed: 42 })
+save('age', initial)
+
+const reloaded = load<number>('age')
+console.log('reloaded:', reloaded && Field.show(reloaded))
+
+// Junk input is rejected — parse returns undefined rather than throwing.
+storage.set('junk', JSON.stringify({ tag: 'NotARealField', oops: true }))
+console.log('junk:', load<number>('junk')) // undefined
+
+// ---------------------------------------------------------------------------
+// 4. Dirty-check with `equals`
+// ---------------------------------------------------------------------------
+
+const isDirty = <A>(previous: Field<A>, current: Field<A>): boolean =>
+  !Field.equals(previous, current)
+
+const current: Field<number> = Field.Typing({ raw: '42' })
+const edited: Field<number> = Field.Typing({ raw: '100' })
+const sameAsInitial: Field<number> = Field.Valid({ raw: '42', parsed: 42 })
+
+console.log('dirty vs edited     :', isDirty(initial, edited)) // true
+console.log('dirty vs current    :', isDirty(initial, current)) // true
+console.log('dirty vs sameAsInit :', isDirty(initial, sameAsInitial)) // false
+
+// ---------------------------------------------------------------------------
+// 5. The full picture — Save button state
+// ---------------------------------------------------------------------------
+
+const saveButton = <A>(original: Field<A>, current: Field<A>): string => {
+  if (!isDirty(original, current)) return 'Save [disabled — no changes]'
+  return Field.match(current, {
+    Empty: () => 'Save [disabled — empty]',
+    Typing: () => 'Save [disabled — still typing]',
+    Invalid: ({ reason }) => `Save [disabled — ${reason}]`,
+    Valid: () => 'Save [enabled]',
+  })
+}
+
+console.log(saveButton(initial, initial)) // no changes
+console.log(saveButton(initial, Field.Typing({ raw: '43' }))) // still typing
+console.log(
+  saveButton(initial, Field.Invalid({ raw: 'abc', reason: 'not a number' })),
+) // not a number
+console.log(saveButton(initial, Field.Valid({ raw: '43', parsed: 43 }))) // enabled

--- a/examples/06-property-testing.ts
+++ b/examples/06-property-testing.ts
@@ -1,0 +1,109 @@
+/**
+ * Example: Property-based testing with fast-check + mkArbitrary.
+ *
+ * Run with:  npx tsx examples/06-property-testing.ts
+ *
+ * Demonstrates:
+ *   - Generating arbitrary values of a tagged union via `mkArbitrary`
+ *   - Using fast-check properties to verify laws about the union:
+ *       1. equals is reflexive
+ *       2. JSON round-trip preserves equals
+ *       3. every generated value matches exactly one guard
+ *       4. parse accepts every generated value
+ *
+ * These properties catch a wide class of bugs that example-based tests
+ * miss, and they take only a few lines to express once you have an
+ * `Arbitrary<Union>` from `mkArbitrary`.
+ *
+ * fast-check is an optional peer dependency of tagged-ts; it only needs
+ * to be installed if you use the `tagged-ts/fast-check` entry point.
+ */
+
+import fc from 'fast-check'
+import { mkArbitrary } from '../src/fast-check'
+import type { MkData, TaggedLambda1 } from '../src/named'
+import { mkTaggedUnion } from '../src/named'
+
+// ---------------------------------------------------------------------------
+// 1. A small union to exercise
+// ---------------------------------------------------------------------------
+
+type Nothing = { readonly tag: 'Nothing' }
+type Just<A> = { readonly tag: 'Just'; readonly value: A }
+type Maybe<A> = Just<A> | Nothing
+
+interface MaybeLambda extends TaggedLambda1 {
+  readonly type: Maybe<this['A']>
+  readonly data: MkData<this['type']>
+}
+
+const Maybe = mkTaggedUnion<MaybeLambda>({ Just: true, Nothing: false })
+
+// ---------------------------------------------------------------------------
+// 2. Build an `Arbitrary<Maybe<number>>`
+// ---------------------------------------------------------------------------
+
+// For every non-nullary member, supply a field arbitrary keyed by field
+// name. Nullary members take `{}`.
+const arbMaybe = mkArbitrary<Maybe<number>>({
+  Just: { value: fc.integer() },
+  Nothing: {},
+})
+
+// ---------------------------------------------------------------------------
+// 3. Properties
+// ---------------------------------------------------------------------------
+
+const check = (label: string, prop: fc.IProperty<unknown>): void => {
+  try {
+    fc.assert(prop, { numRuns: 200 })
+    console.log(`ok   ${label}`)
+  } catch (err) {
+    console.log(`FAIL ${label}`)
+    console.log(String(err))
+  }
+}
+
+// (1) equals is reflexive: a === a
+check(
+  'equals is reflexive',
+  fc.property(arbMaybe, m => Maybe.equals(m, m)),
+)
+
+// (2) JSON round-trip preserves equals
+check(
+  'JSON round-trip preserves equals',
+  fc.property(arbMaybe, m => {
+    const clone = JSON.parse(JSON.stringify(m)) as typeof m
+    return Maybe.equals(m, clone)
+  }),
+)
+
+// (3) every generated value matches exactly one guard
+check(
+  'each value matches exactly one guard',
+  fc.property(arbMaybe, m => {
+    const hits = Maybe.tags.filter(tag => {
+      const guard = Maybe.is[tag as keyof typeof Maybe.is] as (
+        x: unknown,
+      ) => boolean
+      return guard(m)
+    })
+    return hits.length === 1
+  }),
+)
+
+// (4) parse accepts every generated value
+check(
+  'parse accepts every generated value',
+  fc.property(arbMaybe, m => Maybe.parse(m) !== undefined),
+)
+
+// ---------------------------------------------------------------------------
+// 4. Show a few sample values
+// ---------------------------------------------------------------------------
+
+console.log('\nsamples:')
+for (const sample of fc.sample(arbMaybe, 5)) {
+  console.log(' ', Maybe.show(sample))
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,44 @@
+# tagged-ts examples
+
+Runnable examples demonstrating tagged-ts. Every file is self-contained —
+just run it with `tsx`:
+
+```sh
+npx tsx examples/01-maybe.ts
+```
+
+Each example is also typechecked as part of `npm run typecheck` at the
+repo root, so they cannot bit-rot when the library changes.
+
+| File                        | Demonstrates                                                   |
+| --------------------------- | -------------------------------------------------------------- |
+| `01-maybe.ts`               | Basic arity-1 union, named constructors, `match` / `matchW` / `matchOr`, `show`, `tags` |
+| `02-result.ts`              | Arity-2 `Result<E, A>` for error handling; chaining with `matchW` |
+| `03-positional-tree.ts`     | Positional constructors via a recursive `Tree<A>`; folds and in-order traversal with `match` |
+| `04-state-machine.ts`       | Custom discriminant key (`state`); finite-state transitions    |
+| `05-parse-and-equals.ts`    | `parse` for safely hydrating `unknown` at a boundary; `equals` for dirty-check |
+| `06-property-testing.ts`    | `mkArbitrary` + fast-check for property-based tests            |
+
+## Imports
+
+These examples import from `../src/...` because they live inside the
+repo. In your own project you would import from the published package:
+
+```ts
+import { mkTaggedUnion } from 'tagged-ts/named'
+import { mkTaggedUnion } from 'tagged-ts/positional'
+import { mkArbitrary } from 'tagged-ts/fast-check'
+```
+
+## Which style should I use?
+
+- **Named** (`tagged-ts/named`) — constructors take a single object with
+  named fields: `Maybe.Just({ value: 42 })`. Preferred when field names
+  carry meaning. Covered in `01`, `02`, `04`, `05`, `06`.
+- **Positional** (`tagged-ts/positional`) — constructors take positional
+  arguments: `Tree.Node(left, value, right)`. Preferred when field names
+  add no information (classic ADT cases like lists and trees). Covered
+  in `03`.
+
+Both styles share the same runtime utilities (`match`, `show`, `equals`,
+`parse`, `tags`, `is.*`) and the same type-level guarantees.

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["../src/**/*", "./**/*"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tagged-ts",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tagged-ts",
-      "version": "0.3.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",
@@ -16,8 +16,17 @@
         "fast-check": "^4.6.0",
         "rollup": "^4.60.1",
         "rollup-plugin-swc3": "^0.12.1",
+        "tsx": "^4.21.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.4"
+      },
+      "peerDependencies": {
+        "fast-check": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fast-check": {
+          "optional": true
+        }
       }
     },
     "node_modules/@biomejs/biome": {
@@ -226,6 +235,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@fastify/deepmerge": {
@@ -1449,6 +1900,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2195,6 +2688,26 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "rm -rf dist && rollup -c rollup.config.mjs && tsc -p tsconfig.build.json && cp dist/index.d.ts dist/index.d.cts && cp dist/named/index.d.ts dist/named/index.d.cts && cp dist/positional/index.d.ts dist/positional/index.d.cts && cp dist/fast-check/index.d.ts dist/fast-check/index.d.cts",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p examples/tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:types": "vitest --run --typecheck.only",
@@ -83,6 +83,7 @@
     "fast-check": "^4.6.0",
     "rollup": "^4.60.1",
     "rollup-plugin-swc3": "^0.12.1",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,11 @@
   resolved "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz"
   integrity sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==
 
+"@esbuild/darwin-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz"
+  integrity sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==
+
 "@fastify/deepmerge@^2.0.0":
   version "2.0.2"
   resolved "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-2.0.2.tgz"
@@ -244,6 +249,38 @@ es-module-lexer@^2.0.0:
   resolved "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz"
   integrity sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==
 
+"esbuild@^0.27.0 || ^0.28.0", esbuild@~0.27.0:
+  version "0.27.7"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz"
+  integrity sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.27.7"
+    "@esbuild/android-arm" "0.27.7"
+    "@esbuild/android-arm64" "0.27.7"
+    "@esbuild/android-x64" "0.27.7"
+    "@esbuild/darwin-arm64" "0.27.7"
+    "@esbuild/darwin-x64" "0.27.7"
+    "@esbuild/freebsd-arm64" "0.27.7"
+    "@esbuild/freebsd-x64" "0.27.7"
+    "@esbuild/linux-arm" "0.27.7"
+    "@esbuild/linux-arm64" "0.27.7"
+    "@esbuild/linux-ia32" "0.27.7"
+    "@esbuild/linux-loong64" "0.27.7"
+    "@esbuild/linux-mips64el" "0.27.7"
+    "@esbuild/linux-ppc64" "0.27.7"
+    "@esbuild/linux-riscv64" "0.27.7"
+    "@esbuild/linux-s390x" "0.27.7"
+    "@esbuild/linux-x64" "0.27.7"
+    "@esbuild/netbsd-arm64" "0.27.7"
+    "@esbuild/netbsd-x64" "0.27.7"
+    "@esbuild/openbsd-arm64" "0.27.7"
+    "@esbuild/openbsd-x64" "0.27.7"
+    "@esbuild/openharmony-arm64" "0.27.7"
+    "@esbuild/sunos-x64" "0.27.7"
+    "@esbuild/win32-arm64" "0.27.7"
+    "@esbuild/win32-ia32" "0.27.7"
+    "@esbuild/win32-x64" "0.27.7"
+
 estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz"
@@ -283,7 +320,7 @@ function-bind@^1.1.2:
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-tsconfig@^4.8.1:
+get-tsconfig@^4.7.5, get-tsconfig@^4.8.1:
   version "4.13.7"
   resolved "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz"
   integrity sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==
@@ -522,6 +559,16 @@ tinyrainbow@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz"
   integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
+
+tsx@^4.21.0, tsx@^4.8.1:
+  version "4.21.0"
+  resolved "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz"
+  integrity sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==
+  dependencies:
+    esbuild "~0.27.0"
+    get-tsconfig "^4.7.5"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 typescript@^6.0.2:
   version "6.0.2"


### PR DESCRIPTION
## Summary

Adds an `examples/` directory with six self-contained, runnable snippets that cover the full feature surface of tagged-ts. Each file runs directly with `npx tsx examples/NN-foo.ts` and is typechecked in CI so the examples cannot bit-rot when the library changes.

## Examples

| File                        | Demonstrates |
| --------------------------- | ------------ |
| `01-maybe.ts`               | Arity-1 union, named constructors, `match` / `matchW` / `matchOr`, `show`, `tags` |
| `02-result.ts`              | Arity-2 `Result<E, A>` for error handling; chaining with `matchW` |
| `03-positional-tree.ts`     | Recursive `Tree<A>` with positional constructors; folds and in-order traversal |
| `04-state-machine.ts`       | Custom discriminant key (`state`); finite-state transitions |
| `05-parse-and-equals.ts`    | `parse` for hydrating `unknown` at a boundary; `equals` for dirty-check |
| `06-property-testing.ts`    | `mkArbitrary` + fast-check for property-based tests |

Both named and positional styles are covered. All v0.6 runtime utilities (`tags`, `show`, `equals`, `parse`, `mkArbitrary`) appear in at least one snippet.

## Wiring

- `examples/tsconfig.json` extends the root tsconfig and adds `"types": ["node"]` so snippets can use `console` without polluting the library's `src/` typecheck.
- Root `typecheck` script chains a second `tsc --noEmit -p examples/tsconfig.json` pass so examples are checked in CI.
- `biome.json` includes `examples/**` for lint/format.
- `tsx` added as a devDependency for the `npx tsx` runner.