### PR TITLE
Fix show: recurse into nested members, render DAGs without false cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,18 @@ Stream.show(Stream.Emit('s', 42))  // 'Emit("s", 42)'
 Stream.show(Stream.End)            // 'End'
 ```
 
-Field values are formatted with `JSON.stringify`.
+Nested members of the same union are formatted recursively, so recursive
+types like `Tree<A>` or JSON ASTs pretty-print correctly:
+
+```ts
+Tree.show(Tree.Node(Tree.Leaf, 'root', Tree.Node(Tree.Leaf, 'right', Tree.Leaf)))
+// 'Node(Leaf, "root", Node(Leaf, "right", Leaf))'
+```
+
+Foreign values (primitives, arrays, plain objects, `Date`, `Map`, `Set`,
+class instances) are rendered by a generic formatter similar to
+`util.inspect`. True cycles are marked `[Circular]`; shared references
+without a cycle (DAGs) are rendered in full.
 
 ### `equals(a, b)` — Structural deep equality
 

--- a/examples/03-positional-tree.ts
+++ b/examples/03-positional-tree.ts
@@ -9,6 +9,9 @@
  *   - A recursive tagged union (Tree<A> contains Tree<A>)
  *   - Folding the structure via `match` to compute sum, size, and depth
  *   - In-order traversal as another `match` fold
+ *   - Pretty-printing with `show` — recurses into nested members of the same
+ *     union, so a Tree renders as `Node(Leaf, "root", Node(...))` rather
+ *     than as a raw object literal
  *
  * Positional style is handy when the field names add no real information
  * (e.g. a binary tree's left / value / right). Named style is usually
@@ -100,3 +103,15 @@ const inorder = <A>(t: Tree<A>): A[] =>
   })
 
 console.log('inorder:', inorder(tree)) // [1, 3, 4, 5, 8, 9]
+
+// ---------------------------------------------------------------------------
+// 5. Pretty-print with `show` — recurses into nested Nodes of the same union
+// ---------------------------------------------------------------------------
+
+const tiny: Tree<string> = Tree.Node(
+  Tree.Leaf,
+  'root',
+  Tree.Node(Tree.Leaf, 'right', Tree.Leaf),
+)
+console.log('show:', Tree.show(tiny))
+// Node(Leaf, "root", Node(Leaf, "right", Leaf))

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ repo root, so they cannot bit-rot when the library changes.
 | --------------------------- | -------------------------------------------------------------- |
 | `01-maybe.ts`               | Basic arity-1 union, named constructors, `match` / `matchW` / `matchOr`, `show`, `tags` |
 | `02-result.ts`              | Arity-2 `Result<E, A>` for error handling; chaining with `matchW` |
-| `03-positional-tree.ts`     | Positional constructors via a recursive `Tree<A>`; folds and in-order traversal with `match` |
+| `03-positional-tree.ts`     | Positional constructors via a recursive `Tree<A>`; folds, traversal, recursive `show` |
 | `04-state-machine.ts`       | Custom discriminant key (`state`); finite-state transitions    |
 | `05-parse-and-equals.ts`    | `parse` for safely hydrating `unknown` at a boundary; `equals` for dirty-check |
 | `06-property-testing.ts`    | `mkArbitrary` + fast-check for property-based tests            |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tagged-ts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tagged-ts",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tagged-ts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A tagged unions code generation library for discriminating tastes",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/internal/shared.ts
+++ b/src/internal/shared.ts
@@ -603,10 +603,24 @@ const deepEqualsInner = (
  * - Maps: `Map("k" => 1, "j" => 2)`
  * - Sets: `Set(1, 2, 3)`
  * - Cycles: `[Circular]` placeholder where a value refers to an ancestor
+ *   on the current traversal path (DAGs with shared references are rendered
+ *   in full — only true cycles are marked)
+ *
+ * `formatMember` lets a caller customize rendering of objects it recognizes.
+ * If provided, it is called on every non-null object before default handling;
+ * returning a string short-circuits with that output, returning `undefined`
+ * falls through to default formatting. Used by each tagged-union's `show` to
+ * recurse into nested members of the same union.
  *
  * @internal
  */
-export const formatValue = (v: unknown): string => {
+export const formatValue = (
+  v: unknown,
+  formatMember?: (
+    obj: Record<string, unknown>,
+    recurse: (x: unknown) => string,
+  ) => string | undefined,
+): string => {
   const seen = new WeakSet<object>()
   const go = (x: unknown): string => {
     if (x === null) return 'null'
@@ -628,31 +642,40 @@ export const formatValue = (v: unknown): string => {
     const obj = x as object
     if (seen.has(obj)) return '[Circular]'
     seen.add(obj)
-    if (Array.isArray(obj)) return `[${obj.map(go).join(', ')}]`
-    if (obj instanceof Date) return `Date(${JSON.stringify(obj.toISOString())})`
-    if (obj instanceof RegExp) return obj.toString()
-    if (obj instanceof Error)
-      return `${obj.name}(${JSON.stringify(obj.message)})`
-    if (obj instanceof Map) {
-      const entries = Array.from(obj.entries())
-        .map(([k, v]) => `${go(k)} => ${go(v)}`)
+    try {
+      if (formatMember !== undefined) {
+        const out = formatMember(obj as Record<string, unknown>, go)
+        if (out !== undefined) return out
+      }
+      if (Array.isArray(obj)) return `[${obj.map(go).join(', ')}]`
+      if (obj instanceof Date)
+        return `Date(${JSON.stringify(obj.toISOString())})`
+      if (obj instanceof RegExp) return obj.toString()
+      if (obj instanceof Error)
+        return `${obj.name}(${JSON.stringify(obj.message)})`
+      if (obj instanceof Map) {
+        const entries = Array.from(obj.entries())
+          .map(([k, v]) => `${go(k)} => ${go(v)}`)
+          .join(', ')
+        return `Map(${entries})`
+      }
+      if (obj instanceof Set) {
+        const values = Array.from(obj.values()).map(go).join(', ')
+        return `Set(${values})`
+      }
+      const keys = Object.keys(obj)
+      const inner = keys
+        .map(k => `${k}: ${go((obj as Record<string, unknown>)[k])}`)
         .join(', ')
-      return `Map(${entries})`
+      const proto = Object.getPrototypeOf(obj)
+      const isPlain = proto === null || proto === Object.prototype
+      if (isPlain) return keys.length === 0 ? '{}' : `{ ${inner} }`
+      const className =
+        (proto?.constructor as { name?: string } | undefined)?.name ?? 'Object'
+      return keys.length === 0 ? `${className} {}` : `${className} { ${inner} }`
+    } finally {
+      seen.delete(obj)
     }
-    if (obj instanceof Set) {
-      const values = Array.from(obj.values()).map(go).join(', ')
-      return `Set(${values})`
-    }
-    const keys = Object.keys(obj)
-    const inner = keys
-      .map(k => `${k}: ${go((obj as Record<string, unknown>)[k])}`)
-      .join(', ')
-    const proto = Object.getPrototypeOf(obj)
-    const isPlain = proto === null || proto === Object.prototype
-    if (isPlain) return keys.length === 0 ? '{}' : `{ ${inner} }`
-    const className =
-      (proto?.constructor as { name?: string } | undefined)?.name ?? 'Object'
-    return keys.length === 0 ? `${className} {}` : `${className} { ${inner} }`
   }
   return go(v)
 }

--- a/src/named/index.ts
+++ b/src/named/index.ts
@@ -254,16 +254,17 @@ const mkTaggedUnionImpl = <F extends TaggedLambda0, DK extends string>(
 
   const guardsAndMatchers = mkGuardsAndMatchers(dk, memberTags)
   const features = mkSharedFeatures(dk, memberTags)
+  const tagSet = new Set(memberTags)
 
-  const show = (a: unknown): string => {
-    if (typeof a !== 'object' || a === null) return String(a)
-    const rec = a as Record<string, unknown>
-    const tag = rec[dk]
-    const fieldKeys = Object.keys(rec).filter(k => k !== dk)
-    if (fieldKeys.length === 0) return String(tag)
-    const inner = fieldKeys.map(k => `${k}: ${formatValue(rec[k])}`).join(', ')
-    return `${String(tag)}({ ${inner} })`
-  }
+  const show = (a: unknown): string =>
+    formatValue(a, (obj, recurse) => {
+      const tag = obj[dk]
+      if (typeof tag !== 'string' || !tagSet.has(tag)) return undefined
+      const fieldKeys = Object.keys(obj).filter(k => k !== dk)
+      if (fieldKeys.length === 0) return tag
+      const inner = fieldKeys.map(k => `${k}: ${recurse(obj[k])}`).join(', ')
+      return `${tag}({ ${inner} })`
+    })
 
   return {
     ...constructors,

--- a/src/positional/index.ts
+++ b/src/positional/index.ts
@@ -310,16 +310,17 @@ const mkTaggedUnionImpl = <
 
   const guardsAndMatchers = mkGuardsAndMatchers(dk, memberTags)
   const features = mkSharedFeatures(dk, memberTags)
+  const tagSet = new Set(memberTags)
 
-  const show = (a: unknown): string => {
-    if (typeof a !== 'object' || a === null) return String(a)
-    const rec = a as Record<string, unknown>
-    const tag = rec[dk]
-    const orderedFields = fieldOrder[tag as string] ?? []
-    if (orderedFields.length === 0) return String(tag)
-    const inner = orderedFields.map(k => formatValue(rec[k])).join(', ')
-    return `${String(tag)}(${inner})`
-  }
+  const show = (a: unknown): string =>
+    formatValue(a, (obj, recurse) => {
+      const tag = obj[dk]
+      if (typeof tag !== 'string' || !tagSet.has(tag)) return undefined
+      const orderedFields = fieldOrder[tag] ?? []
+      if (orderedFields.length === 0) return tag
+      const inner = orderedFields.map(k => recurse(obj[k])).join(', ')
+      return `${tag}(${inner})`
+    })
 
   return {
     ...constructors,

--- a/test/named/features.test.ts
+++ b/test/named/features.test.ts
@@ -144,15 +144,26 @@ describe('show (named)', () => {
     ).toBe('Just({ value: "say \\"hi\\"" })')
   })
 
-  it('renders a tagged union nested inside another as a plain object', () => {
-    // Nested member is a plain object from formatValue's perspective.
+  it('recursively renders nested members of the same union', () => {
     expect(
       Maybe.show(
         Maybe.Just({
           value: Maybe.Just({ value: 1 }) as unknown as number,
         }),
       ),
-    ).toBe('Just({ value: { tag: "Just", value: 1 } })')
+    ).toBe('Just({ value: Just({ value: 1 }) })')
+  })
+
+  it('renders a tagged union from a different shape as a plain object', () => {
+    // CounterAction uses discriminant 'type' — not recognized as a Maybe
+    // member, so it renders via the generic object formatter.
+    expect(
+      Maybe.show(
+        Maybe.Just({
+          value: CounterAction.Reset as unknown as number,
+        }),
+      ),
+    ).toBe('Just({ value: { type: "Reset" } })')
   })
 
   it('renders bigint, symbol, function, -0', () => {
@@ -241,6 +252,71 @@ describe('show (named)', () => {
     expect(Maybe.show(Maybe.Just({ value: [] as unknown as number }))).toBe(
       'Just({ value: [] })',
     )
+  })
+
+  it('renders shared references (DAG) without false [Circular]', () => {
+    // Two fields point to the same object — not a cycle, both should
+    // render in full.
+    const shared = { n: 1 }
+    expect(
+      Maybe.show(
+        Maybe.Just({
+          value: { a: shared, b: shared } as unknown as number,
+        }),
+      ),
+    ).toBe('Just({ value: { a: { n: 1 }, b: { n: 1 } } })')
+  })
+
+  it('recursively pretty-prints a recursive tagged union (JsonValue)', () => {
+    type JNull = { readonly tag: 'JNull' }
+    type JBool = { readonly tag: 'JBool'; readonly value: boolean }
+    type JNum = { readonly tag: 'JNum'; readonly value: number }
+    type JArr = { readonly tag: 'JArr'; readonly items: readonly JsonValue[] }
+    type JObj = {
+      readonly tag: 'JObj'
+      readonly entries: ReadonlyArray<{
+        readonly key: string
+        readonly value: JsonValue
+      }>
+    }
+    type JsonValue = JNull | JBool | JNum | JArr | JObj
+    interface JsonLambda extends TaggedLambda0 {
+      readonly type: JsonValue
+      readonly data: MkData<this['type']>
+    }
+    const J = mkTaggedUnion<JsonLambda>({
+      JNull: false,
+      JBool: true,
+      JNum: true,
+      JArr: true,
+      JObj: true,
+    })
+    const v: JsonValue = J.JObj({
+      entries: [
+        { key: 'n', value: J.JNum({ value: 1 }) },
+        { key: 'ok', value: J.JBool({ value: true }) },
+        {
+          key: 'list',
+          value: J.JArr({ items: [J.JNum({ value: 2 }), J.JNull] }),
+        },
+      ],
+    })
+    expect(J.show(v)).toBe(
+      'JObj({ entries: [' +
+        '{ key: "n", value: JNum({ value: 1 }) }, ' +
+        '{ key: "ok", value: JBool({ value: true }) }, ' +
+        '{ key: "list", value: JArr({ items: [JNum({ value: 2 }), JNull] }) }' +
+        '] })',
+    )
+  })
+
+  it('does not flag repeated nullary singletons as [Circular]', () => {
+    // Reusing Maybe.Nothing (a nullary singleton) in multiple positions
+    // of a plain-object container must not trip cycle detection.
+    const n = Maybe.Nothing
+    expect(
+      Maybe.show(Maybe.Just({ value: { a: n, b: n } as unknown as number })),
+    ).toBe('Just({ value: { a: Nothing, b: Nothing } })')
   })
 })
 

--- a/test/positional/features.test.ts
+++ b/test/positional/features.test.ts
@@ -123,12 +123,15 @@ describe('show (positional)', () => {
     )
   })
 
-  it('renders a tagged union nested inside another as a plain object', () => {
-    // Nested member has no prototype distinction — formatValue sees it as plain
-    // and renders its own `tag` key verbatim.
+  it('recursively renders nested members of the same union', () => {
     expect(Maybe.show(Maybe.Just(Maybe.Just(1) as unknown as number))).toBe(
-      'Just({ tag: "Just", value: 1 })',
+      'Just(Just(1))',
     )
+  })
+
+  it('renders a tagged union from a different shape as a plain object', () => {
+    // Stream is a different union — its members aren't in Maybe's tag set,
+    // so they render via the generic object formatter.
     expect(
       Maybe.show(Maybe.Just(Stream.Emit('s', 42) as unknown as number)),
     ).toBe('Just({ tag: "Emit", state: "s", value: 42 })')
@@ -220,6 +223,51 @@ describe('show (positional)', () => {
     cyclic.self = cyclic
     expect(Maybe.show(Maybe.Just(cyclic as unknown as number))).toBe(
       'Just({ self: [Circular] })',
+    )
+  })
+
+  it('renders shared references (DAG) without false [Circular]', () => {
+    // The two entries share the same object reference but there is no
+    // cycle — both should render in full.
+    const shared = { n: 1 }
+    expect(
+      Maybe.show(Maybe.Just({ a: shared, b: shared } as unknown as number)),
+    ).toBe('Just({ a: { n: 1 }, b: { n: 1 } })')
+  })
+
+  it('recursively pretty-prints a recursive tagged union (Tree)', () => {
+    type Leaf = { readonly tag: 'Leaf' }
+    type Node<A> = {
+      readonly tag: 'Node'
+      readonly left: Tree<A>
+      readonly value: A
+      readonly right: Tree<A>
+    }
+    type Tree<A> = Leaf | Node<A>
+    interface TreeLambda extends TaggedLambda1 {
+      readonly type: Tree<this['A']>
+      readonly data: MkData<this['type']>
+    }
+    const Tree = mkTaggedUnion<TreeLambda>()({
+      Leaf: [],
+      Node: ['left', 'value', 'right'],
+    })
+    const t: Tree<number> = Tree.Node(
+      Tree.Node(Tree.Leaf, 1, Tree.Leaf),
+      2,
+      Tree.Node(Tree.Leaf, 3, Tree.Leaf),
+    )
+    expect(Tree.show(t)).toBe(
+      'Node(Node(Leaf, 1, Leaf), 2, Node(Leaf, 3, Leaf))',
+    )
+  })
+
+  it('does not flag repeated nullary singletons as [Circular]', () => {
+    // Reusing Maybe.Nothing (a nullary singleton) in multiple positions
+    // of a plain-object container must not trip cycle detection.
+    const n = Maybe.Nothing
+    expect(Maybe.show(Maybe.Just({ a: n, b: n } as unknown as number))).toBe(
+      'Just({ a: Nothing, b: Nothing })',
     )
   })
 })


### PR DESCRIPTION
## Summary

Fixes two related bugs in tagged-ts's \`show\` output that were flagged as a follow-up after the examples PR (#22) hit the limitation in \`examples/03-positional-tree.ts\`.

### Bug 1 — DAGs reported as cycles

\`formatValue\`'s cycle detection used a \`WeakSet\` that was never cleared during traversal, so any object appearing twice in the same value was marked \`[Circular]\` on the second occurrence, even without an actual cycle. Trivial to reproduce because nullary tagged-union members are frozen singletons: reusing \`Tree.Leaf\` in both children of a \`Node\` misreports the second leaf.

Fix: wrap per-object work in \`try/finally\` and delete the object from the seen set on exit, so the set tracks the current ancestry path rather than accumulating across the whole traversal. True cycles are still marked \`[Circular]\`.

### Bug 2 — \`show\` didn't recurse into nested members of the same union

Both styles' \`show\` called \`formatValue\` on each field value. \`formatValue\` is a generic pretty-printer that doesn't know about tagged unions, so a child \`Node\` inside a \`Tree\` rendered as \`{ tag: \"Node\", left: ..., value: ..., right: ... }\` instead of \`Node(...)\`. Recursive types like \`Tree<A>\` and JSON ASTs are the primary use case for tagged unions, so this was a visible ergonomic gap. v0.6 tests codified the old behavior with an apologetic comment (\"Nested member is a plain object from formatValue's perspective\").

Fix: \`formatValue\` gains an optional \`formatMember\` callback. Each style's \`show\` passes a hook that recognizes own-union members (matches the discriminant key against the union's tag set) and self-recurses via the \`recurse\` callback formatValue provides. Foreign values (primitives, arrays, plain objects, \`Date\`, \`Map\`, \`Set\`, class instances, other tagged unions) fall through to default formatting. Cycle detection applies uniformly to both paths.

### Scope of observable change

- \`Maybe.show(Maybe.Just({ value: Maybe.Just({ value: 1 }) }))\` now returns \`'Just({ value: Just({ value: 1 }) })'\` instead of \`'Just({ value: { tag: \"Just\", value: 1 } })'\`.
- Same for positional: \`'Just(Just(1))'\` instead of \`'Just({ tag: \"Just\", value: 1 })'\`.
- Foreign-shape nesting (e.g., a value from a union with a different discriminant key) is unchanged — still renders as a plain object.

This is a bug-fix minor bump: **0.6.0 → 0.6.1**.

## Test coverage

- Updated the two tests that codified the old non-recursing behavior.
- Added: DAG-not-cycle, recursive Tree pretty-print (positional), recursive JSON ADT pretty-print (named), repeated nullary singletons, cross-shape rendering fallback.
- Restored the \`show\` demo in \`examples/03-positional-tree.ts\` now that output is meaningful; updated README \`show\` section.

Test totals: 608 → 616 (2 updated, 8 new).