### PR TITLE
Add publish-on-tag workflow with npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} (=${TAG_VERSION}) does not match package.json version ${PKG_VERSION}"
+            exit 1
+          fi
+
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm run test
+      - run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes


### PR DESCRIPTION
## Summary

Automates releases so tagging `vX.Y.Z` on master → full CI re-run → `npm publish --provenance` → GitHub release with auto-generated notes. No third-party actions.

## How it works

Trigger: `push` of a tag matching `v*`.

Steps:
1. **Verify tag matches `package.json` version** — if someone tags `v0.7.0` but master still has `"version": "0.6.1"`, the workflow fails fast before publishing anything. Prevents mistyped or out-of-order tags from creating broken releases.
2. **Re-run the full check pipeline** — `typecheck` + `lint` + `test` + `build`. Self-contained; does not depend on CI workflow results so the workflow is correct even if run out-of-band.
3. **`npm publish --provenance --access public`** — npm attaches an OIDC provenance statement linking the published tarball back to this workflow run. Published versions will show a green provenance badge on npmjs.com.
4. **Create GitHub release** — `gh release create "$GITHUB_REF_NAME" --generate-notes`. Pre-installed `gh` CLI, no third-party action.

Permissions granted on the job:
- `contents: write` — for creating the GitHub release
- `id-token: write` — for npm OIDC provenance

## Prereq on the repo

An `NPM_TOKEN` secret needs to be saved under **Settings → Secrets and variables → Actions**. That should be an **automation token** from npmjs.com (not a legacy classic token — automation tokens bypass 2FA prompts so CI can publish unattended). The token must have publish rights on the `tagged-ts` package.

## How to cut a release after this merges

1. Bump `package.json` version on master (e.g. 0.6.0 → 0.6.1).
2. `git tag v0.6.1 && git push origin v0.6.1`.
3. Workflow fires, re-runs checks, publishes to npm with provenance, creates the GitHub release.

For the pending 0.6.1 (already on master from #23), this means: just tag and push once the workflow + `NPM_TOKEN` secret are in place.