### PR TITLE
Include test:types in check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "check": "npm run typecheck && npm run lint && npm run test",
+    "check": "npm run typecheck && npm run lint && npm run test && npm run test:types",
     "prepublishOnly": "npm run check && npm run build"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- Add `npm run test:types` to the `check` script so type-test regressions are caught by the full pipeline (and by `prepublishOnly`, which runs `check`).
