### PR TITLE
Opt publish workflow into Node.js 24 for JS actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` so `actions/checkout@v4` and `actions/setup-node@v4` run on Node.js 24 instead of the deprecated Node.js 20 runtime. Clears the deprecation warning logged on the v0.6.1 publish run. Default flips on 2026-06-02.
